### PR TITLE
fix(domain.zone.record): add .word-break to target value

### DIFF
--- a/client/app/domain/zone/record/resume.html
+++ b/client/app/domain/zone/record/resume.html
@@ -16,7 +16,7 @@
             data-ng-bind="ctrl.model.ttl"></dd>
 
         <dt data-i18n-static="domain_configuration_dns_entry_add_target"></dt>
-        <dd data-ng-bind="ctrl.model.target.value"></dd>
+        <dd class="word-break" data-ng-bind="ctrl.model.target.value"></dd>
     </dl>
 
     <div class="alert alert-warning mt-4" role="alert"


### PR DESCRIPTION
## fix(domain.zone.record): add .word-break to target value


### Description of the Change

Currently, the target value doesn't wrap long values. Added the class .word-break to add correct wrapping styles.

### Benefits

Wraps long values instead of breaking out of the model UI breaking UX.

**Before:**
![image](https://user-images.githubusercontent.com/10200431/30283769-eb6b3998-9710-11e7-8a74-2d793b79003d.png)

**After**
![image](https://user-images.githubusercontent.com/10200431/30283790-fd6d7ff2-9710-11e7-9649-83bb30dcc2eb.png)

