### PR TITLE
fix(*): added support for older browsers

### DIFF
--- a/Assets.js
+++ b/Assets.js
@@ -103,6 +103,8 @@ module.exports = {
             "client/bower_components/lodash/lodash.min.js",
             "client/bower_components/moment/min/moment-with-locales.min.js",
             "client/bower_components/jquery/dist/jquery.min.js",
+            "client/bower_components/jquery/dist/jquery.min.js",
+            "client/bower_components/babel-browser-polyfill/polyfill.js",
 
             "client/bower_components/jquery.ui/ui/core.js",
             "client/bower_components/jquery.ui/ui/widget.js",

--- a/bower.json
+++ b/bower.json
@@ -92,7 +92,8 @@
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "angular-resource": "^1.6.6",
     "chart.js": "^2.6.0",
-    "chartjs-plugin-zoom": "^0.5.0"
+    "chartjs-plugin-zoom": "^0.5.0",
+    "babel-browser-polyfill": "^6.22.0"
   },
   "resolutions": {
     "angular": "~1.6.0",


### PR DESCRIPTION
## Added support for older browsers

### Description of the Change

When transpiling, Babel will transform ES6 code to code that can be used on most recent and not so recent browser. But while doing so, it will use some features introduced in ES6.

For example:
```javascript
for (const item of array)
```

becomes
```javascript
for (var _iterator = array[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
    var item = _step.value;
}
```

as you can see, ``Symbol``, which is a data type introduced in ES6, is used after the transpiling. Therefore, for our products to work on older browsers, a polyfill must be added to implement those missing features. 

As for why Babel uses ES6 syntax even though its purpose is to be able to write ES6 code on most browsers, it's because some features can't be replicated without newer features introduced recently.

Sources:
* https://github.com/babel/babel/issues/1534
* https://babeljs.io/docs/usage/caveats/

### Benefits

This commit will add the official Babel polyfill and allow our products to work even with browsers which can't handle ES6.