### PR TITLE
fix(domain.zone.record.DKIM): add service type none

### DIFF
--- a/client/app/domain/zone/record/DKIM/domain-zone-record-DKIM.html
+++ b/client/app/domain/zone/record/DKIM/domain-zone-record-DKIM.html
@@ -100,18 +100,30 @@
         <label class="control-label col-md-3"
                data-i18n-static="domain_configuration_dns_entry_add_servicetypes"></label>
         <div class="col-md-9">
-            <label class="radio-inline">
-                <input type="radio" name="s" value="*"
-                       data-ng-change="ctrl.setTargetValue('DKIM')"
-                       data-ng-model="ctrl.model.target.s">
-                <span data-i18n-static="domain_configuration_dns_entry_add_servicetypes_all"></span>
-            </label>
-            <label class="radio-inline ml-4">
-                <input type="radio" name="s" value="email"
-                       data-ng-change="ctrl.setTargetValue('DKIM')"
-                       data-ng-model="ctrl.model.target.s">
-                <span data-i18n-static="domain_configuration_dns_entry_add_servicetypes_email"></span>
-            </label>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="s" value="*"
+                           data-ng-change="ctrl.setTargetValue('DKIM')"
+                           data-ng-model="ctrl.model.target.s">
+                    <span data-i18n-static="domain_configuration_dns_entry_add_servicetypes_all"></span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="s" value="email"
+                           data-ng-change="ctrl.setTargetValue('DKIM')"
+                           data-ng-model="ctrl.model.target.s">
+                    <span data-i18n-static="domain_configuration_dns_entry_add_servicetypes_email"></span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="s" value=""
+                           data-ng-change="ctrl.setTargetValue('DKIM')"
+                           data-ng-model="ctrl.model.target.s">
+                    <span data-i18n-static="domain_configuration_dns_entry_add_servicetypes_none"></span>
+                </label>
+            </div>
         </div>
     </div>
 

--- a/client/app/domain/zone/record/domain-zone-record.controller.js
+++ b/client/app/domain/zone/record/domain-zone-record.controller.js
@@ -66,6 +66,7 @@ angular.module("App").controller(
             this.model.target = {};
             if (this.model.fieldType.toLowerCase() === "dkim") {
                 this.model.target.t = { y: false, s: true };
+                this.model.target.s = "";
             }
             this.setTargetValue(this.model.fieldType);
         }

--- a/client/app/resources/i18n/domain/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/domain/Messages_fr_FR.xml
@@ -586,7 +586,8 @@
    <translation id="domain_configuration_dns_entry_add_publickey_revoke" qtlid="192396">Révoquer la clé publique</translation>
    <translation id="domain_configuration_dns_entry_add_servicetypes" qtlid="192409">Types de service</translation>
    <translation id="domain_configuration_dns_entry_add_servicetypes_all" qtlid="69173">Tous</translation>
-   <translation id="domain_configuration_dns_entry_add_servicetypes_email" qtlid="192422">e-mail</translation>
+   <translation id="domain_configuration_dns_entry_add_servicetypes_email" qtlid="192422">E-mail</translation>
+   <translation id="domain_configuration_dns_entry_add_servicetypes_none">Aucun</translation>
    <translation id="domain_configuration_dns_entry_add_t_y" qtlid="192435">Mode test</translation>
    <translation id="domain_configuration_dns_entry_add_t_y_no" qtlid="24967">Désactivé</translation>
    <translation id="domain_configuration_dns_entry_add_t_y_yes" qtlid="30250">Activé</translation>


### PR DESCRIPTION
## Domain Zone Record DKIM - Add service type none


### Description of the Change

Adds an extra radio button with an empty value called none.

### Benefits

This allows you to remove the `s=*;` or `s=email;` if present in DKIM. 

G Suite fails to validate if they are present in your DKIM for the relevant domain. Before you would have to manually edit the DKIM using "Change in text format" which is not suitable for most people.

### Applicable Issues

See discussion on Gitter https://gitter.im/ovh/ux?at=59b951c2bc464729742c3df3

### Before
![image](https://user-images.githubusercontent.com/10200431/30407051-ec24ec74-98ed-11e7-9a0d-5e430e4989fe.png)


### After
![image](https://user-images.githubusercontent.com/10200431/30407040-cf1ee878-98ed-11e7-934e-ba64af84efe0.png)

