### PR TITLE
style(hosting): make all the alerts show up above the header

### DIFF
--- a/client/app/hosting/database/DATABASE.html
+++ b/client/app/hosting/database/DATABASE.html
@@ -1,4 +1,3 @@
 <div class="container-fluid px-0" data-ng-controller="HostingTabDatabasesCtrl">
-    <div data-ovh-alert="dataBase.alerts.bdd"></div>
     <div data-ng-include="bddTemplate"></div>
 </div>

--- a/client/app/hosting/database/dump/HostingDatabaseDumpsController.js
+++ b/client/app/hosting/database/dump/HostingDatabaseDumpsController.js
@@ -11,10 +11,6 @@ angular.module("App").controller(
 
             this.statusToWatch = ["start", "doing", "done", "error"];
 
-            this.$scope.alerts = {
-                bdd: "dataBase.alerts.bdd"
-            };
-
             _.forEach(this.statusToWatch, (state) => {
                 this.$scope.$on(`database.dump.restore.poll.${state}`, this[`onDataBaseDumpRestore${state}`].bind(this));
                 this.$scope.$on(`database.dump.delete.poll.${state}`, this[`onDataBaseDumpDelete${state}`].bind(this));
@@ -35,7 +31,7 @@ angular.module("App").controller(
             return this.hostingDatabase
                 .getDumpIds(this.$stateParams.productId, this.$scope.bdd.name)
                 .then((dumpIds) => (this.dumpsIds = dumpIds))
-                .catch((err) => this.alerter.alertFromSWS(this.$scope.tr("hosting_tab_databases_get_error"), err, "dataBase.alerts.bdd"))
+                .catch((err) => this.alerter.alertFromSWS(this.$scope.tr("hosting_tab_databases_get_error"), err, this.$scope.alerts.dashboard))
                 .finally(() => {
                     if (_.isEmpty(this.dumpsIds)) {
                         this.dumpsLoading = false;
@@ -78,16 +74,16 @@ angular.module("App").controller(
                 }
             });
 
-            this.alerter.success(this.$scope.tr("database_tabs_dumps_delete_start"), this.$scope.alerts.bdd);
+            this.alerter.success(this.$scope.tr("database_tabs_dumps_delete_start"), this.$scope.alerts.dashboard);
         }
 
         onDataBaseDumpDeletedoing () {
-            this.alerter.success(this.$scope.tr("database_tabs_dumps_delete_in_progress"), this.$scope.alerts.bdd);
+            this.alerter.success(this.$scope.tr("database_tabs_dumps_delete_in_progress"), this.$scope.alerts.dashboard);
         }
 
         onDataBaseDumpDeletedone () {
             this.loadDumps();
-            this.alerter.success(this.$scope.tr("database_tabs_dumps_delete_success"), this.$scope.alerts.bdd);
+            this.alerter.success(this.$scope.tr("database_tabs_dumps_delete_success"), this.$scope.alerts.dashboard);
         }
 
         onDataBaseDumpDeleteerror (dump) {
@@ -95,7 +91,7 @@ angular.module("App").controller(
                 this.findItemIndex(dump.id).then((idx) => {
                     if (~idx) {
                         delete this.dumpsDetails[idx].waitDelete;
-                        this.alerter.error(this.$scope.tr("database_tabs_dumps_delete_fail"), this.$scope.alerts.bdd);
+                        this.alerter.error(this.$scope.tr("database_tabs_dumps_delete_fail"), this.$scope.alerts.dashboard);
                     }
                 });
             }
@@ -106,12 +102,12 @@ angular.module("App").controller(
 
             this.findItemIndex(dump.id).then((idx) => {
                 this.dumpsDetails[idx].waitRestore = true;
-                this.alerter.success(this.$scope.tr("database_tabs_dumps_restore_start"), "dataBase.alerts.bdd");
+                this.alerter.success(this.$scope.tr("database_tabs_dumps_restore_start"), this.$scope.alerts.dashboard);
             });
         }
 
         onDataBaseDumpRestoredoing () {
-            this.alerter.success(this.$scope.tr("database_tabs_dumps_restore_in_progress"), "dataBase.alerts.bdd");
+            this.alerter.success(this.$scope.tr("database_tabs_dumps_restore_in_progress"), this.$scope.alerts.dashboard);
         }
 
         onDataBaseDumpRestoredone () {
@@ -120,7 +116,7 @@ angular.module("App").controller(
             this.dumpsDetails.forEach((dump) => {
                 delete dump.waitRestore;
             });
-            this.alerter.success(this.$scope.tr("database_tabs_dumps_restore_success"), "dataBase.alerts.bdd");
+            this.alerter.success(this.$scope.tr("database_tabs_dumps_restore_success"), this.$scope.alerts.dashboard);
         }
 
         onDataBaseDumpRestoreerror (dump) {
@@ -129,7 +125,7 @@ angular.module("App").controller(
             if (dump && dump.id) {
                 this.findItemIndex(dump.id).then((idx) => {
                     this.dumpsDetails[idx].waitRestore = null;
-                    this.alerter.error(this.$scope.tr("database_tabs_dumps_restore_fail"), "dataBase.alerts.bdd");
+                    this.alerter.error(this.$scope.tr("database_tabs_dumps_restore_fail"), this.$scope.alerts.dashboard);
                 });
             }
         }

--- a/client/app/hosting/database/dump/delete/hosting-database-dump-delete.controller.js
+++ b/client/app/hosting/database/dump/delete/hosting-database-dump-delete.controller.js
@@ -11,7 +11,7 @@ angular.module("App").controller("HostingDatabaseDumpDeleteCtrl", function ($sco
     $scope.deleteDatabaseDump = function () {
         $scope.resetAction();
         HostingDatabase.deleteDatabaseDump($stateParams.productId, $scope.database.name, $scope.dump).catch((err) => {
-            Alerter.alertFromSWS($scope.tr("database_tabs_dumps_delete_fail"), err, "dataBase.alerts.bdd");
+            Alerter.alertFromSWS($scope.tr("database_tabs_dumps_delete_fail"), err, $scope.alerts.dashboard);
         });
     };
 

--- a/client/app/hosting/database/hosting-database.controller.js
+++ b/client/app/hosting/database/hosting-database.controller.js
@@ -112,10 +112,10 @@ angular.module("App").controller("HostingTabDatabasesCtrl", function ($scope, $s
             .then(() => {
                 HostingDatabase.restoreBDDBackup($stateParams.productId, database.name, backupType, sendEmail).then(
                     () => {
-                        Alerter.success($scope.tr("database_tabs_dumps_restore_in_start"), "dataBase.alerts.bdd");
+                        Alerter.success($scope.tr("database_tabs_dumps_restore_in_start"), this.$scope.alerts.dashboard);
                     },
                     (err) => {
-                        Alerter.alertFromSWS($scope.tr("database_tabs_dumps_restore_fail"), err, "dataBase.alerts.bdd");
+                        Alerter.alertFromSWS($scope.tr("database_tabs_dumps_restore_fail"), err, this.$scope.alerts.dashboard);
                     }
                 );
             })

--- a/client/app/hosting/database/restore/hosting-database-restore.controller.js
+++ b/client/app/hosting/database/restore/hosting-database-restore.controller.js
@@ -10,10 +10,10 @@ angular.module("App").controller("HostingDatabaseRestoreCtrl", ($scope, $statePa
         HostingDatabase.restoreBDD($stateParams.productId, $scope.bdd.name, $scope.dump)
             .then(
                 () => {
-                    Alerter.success($scope.tr("database_tabs_dumps_restore_in_start"), "dataBase.alerts.bdd");
+                    Alerter.success($scope.tr("database_tabs_dumps_restore_in_start"), $scope.alerts.dashboard);
                 },
                 (err) => {
-                    Alerter.alertFromSWS($scope.tr("database_tabs_dumps_restore_fail"), err, "dataBase.alerts.bdd");
+                    Alerter.alertFromSWS($scope.tr("database_tabs_dumps_restore_fail"), err, $scope.alerts.dashboard);
                 }
             )
             .finally(() => {


### PR DESCRIPTION
## Make all the alerts show up above the header

### Description of the Change

Some alerts displayed to confirm actions on the database
were showing up in their own space, making the ux inconsistent.

A seemingly old `<div data-ovh-alert="dataBase.alerts.bdd"></div>` was receiving alerts and displaying them instead of using the header bar.

I replaced all references to `"dataBase.alerts.bdd"` by a cleaner `$scope.alerts.dashboard`.

### Benefits

All changes in the database tab are now confirmed through the header.