### PR TITLE
chore(npm): update ovh-ui-kit-bs to v0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5648,7 +5648,7 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "git+https://github.com/whitequark/ipaddr.js.git#b56c0f5f49d71015fdf3edc2607d66955ab85f33"
+      "version": "git+https://github.com/whitequark/ipaddr.js.git#d384881bd33cefda9c56eda74bc122350a31bd6a"
     },
     "irregular-plurals": {
       "version": "1.3.0",
@@ -7720,7 +7720,7 @@
       }
     },
     "ovh-ui-kit-bs": {
-      "version": "git+https://github.com/ovh-ux/ovh-ui-kit-bs.git#b35a167626ebc1fbfdb03a821600a134c4c417ee",
+      "version": "git+https://github.com/ovh-ux/ovh-ui-kit-bs.git#6d76208edc1b3c3c0088a67b1e88e1e7893bd742",
       "dev": true,
       "requires": {
         "less-plugin-remcalc": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "less-plugin-remcalc": "0.0.1",
     "ovh-protractor-jasmine2-logs-reporter": "0.0.1",
     "ovh-ui-kit": "git+https://github.com/ovh-ux/ovh-ui-kit#v1.0.0-alpha.19",
-    "ovh-ui-kit-bs": "git+https://github.com/ovh-ux/ovh-ui-kit-bs.git#v0.4.4",
+    "ovh-ui-kit-bs": "git+https://github.com/ovh-ux/ovh-ui-kit-bs.git#v0.4.5",
     "prettier-eslint": "^6.2.2",
     "protractor-jasmine2-screenshot-reporter": "^0.3.0",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
It'll be great if we can publish [ovh-ui-kit-bs](https://github.com/ovh-ux/ovh-ui-kit-bs) to avoid updating `package.json` every time there is an update :)