### PR TITLE
Fix/domain transfert progress bar

### DIFF
--- a/client/app/domain-operation/progress/domain-operation-progress.controller.js
+++ b/client/app/domain-operation/progress/domain-operation-progress.controller.js
@@ -1,60 +1,76 @@
-angular.module("App").controller("DomainOperationProgressCtrl", class DomainOperationProgressCtrl {
+angular
+    .module("App")
+    .controller("DomainOperationProgressCtrl", class DomainOperationProgressCtrl {
+        constructor (Alerter, domainOperationService, $scope, $stateParams) {
+            this.Alerter = Alerter;
+            this.Operation = domainOperationService;
+            this.$scope = $scope;
+            this.$stateParams = $stateParams;
+        }
 
-    constructor ($scope, $stateParams, Alerter, domainOperationService) {
-        this.$scope = $scope;
-        this.$stateParams = $stateParams;
-        this.Alerter = Alerter;
-        this.Operation = domainOperationService;
-    }
+        $onInit () {
+            this.$scope.alerts = { dashboard: "domains.operations.alerts" };
+            this.currentStepIndex = 0;
+            this.loading = false;
+            this.progress = null;
+            this.steps = [
+                { name: "contactsConfirmation", active: false, position: 17 },
+                { name: "confirmationOfTheCurrentRegistrar", active: false, position: 50 },
+                { name: "finalizationOfTheTransfer", active: false, position: 84 }
+            ];
 
-    $onInit () {
-        this.$scope.alerts = { dashboard: "domains.operations.alerts" };
-        this.currentStepIndex = 0;
-        this.loading = false;
-        this.progress = null;
-        this.steps = [
-            { name: "contactsConfirmation", active: false, position: 17 },
-            { name: "confirmationOfTheCurrentRegistrar", active: false, position: 50 },
-            { name: "finalizationOfTheTransfer", active: false, position: 84 }
-        ];
+            moment.locale(this.$scope.selectedLanguage.value.split("_")[0]);
 
+            return this.getProgress();
+        }
 
-        moment.locale(this.$scope.selectedLanguage.value.split("_")[0]);
+        getProgress () {
+            this.loading = true;
 
-        this.getProgress();
-    }
+            return this.Operation
+                .getOperation(this.$stateParams.operationId)
+                .then((operation) => {
+                    this.domain = operation.domain;
+                    this.creationDate = operation.creationDate;
+                    this.doneDate = operation.doneDate;
 
-    getProgress () {
-        this.loading = true;
-        return this.Operation.getOperation(this.$stateParams.operationId)
-            .then((operation) => {
-                this.domain = operation.domain;
-                this.creationDate = operation.creationDate;
-                this.doneDate = operation.doneDate;
+                    const fullProgressBar = { progress: 100 };
 
-                if (operation.status === "done") {
-                    return { progress: 100 };
-                }
-                return this.Operation.getProgressBar(operation.id);
+                    return operation.status === "done" ? fullProgressBar : this.Operation.getProgressBar(operation.id);
+                })
+                .catch((error) => {
+                    if (!_(error).startsWith("The requested object")) {
+                        this.Alerter.alertFromSWS(this.$scope.tr("domains_operations_error"), error, this.$scope.alerts.main);
+                    }
 
-            })
-            .then((progress) => {
-                this.progress = progress;
+                    return null;
+                })
+                .then((progress) => {
+                    this.progress = progress;
 
-                if (_.get(this.progress, "currentStep.step", false)) {
-                    this.progress.currentStep.step = _.camelCase(this.progress.currentStep.step);
-                    this.progress.followUpSteps = _.map(_.get(this.progress, "followUpSteps", []), (s) => {
-                        s.step = _.camelCase(s.step);
-                        return s;
-                    });
-                    _.set(_.find(this.steps, (step) => step.name === this.progress.currentStep.step), "active", true);
-                    this.currentStepIndex = _.findIndex(this.progress.followUpSteps, { step: this.progress.currentStep.step });
-                    this.timeleft = moment().isBefore(this.progress.expectedDoneDate) ? moment().to(this.progress.expectedDoneDate, true) : null;
-                }
-            })
-            .catch((err) => this.Alerter.alertFromSWS(this.$scope.tr("domains_operations_error"), err, this.$scope.alerts.main))
-            .finally(() => {
-                this.loading = false;
-            });
-    }
+                    const operationIsInProgress = _(this.progress).has("currentStep.step");
+                    if (operationIsInProgress) {
+                        const currentProgressStepName = _(this.progress.currentStep.step).camelCase();
+                        this.progress.currentStep.step = currentProgressStepName;
+
+                        const followUpSteps = _(this.progress).get("followUpSteps", []);
+                        this.progress.followUpSteps = _(followUpSteps).map((followUpStep) => {
+                            followUpStep.step = _(followUpStep.step).camelCase();
+                            return followUpStep;
+                        }).value();
+
+                        const currentStep = _(this.steps).find((step) => step.name === currentProgressStepName);
+                        _.set(currentStep, "active", true);
+                        this.currentStepIndex = _(this.progress.followUpSteps).findIndex({ step: this.progress.currentStep.step });
+
+                        const shouldBeDoneAlready = moment().isBefore(this.progress.expectedDoneDate);
+                        const expectedTimeLeft = moment().to(this.progress.expectedDoneDate, true);
+                        this.timeleft = !shouldBeDoneAlready ? expectedTimeLeft : null;
+                    }
+                })
+                .catch((err) => this.Alerter.alertFromSWS(this.$scope.tr("domains_operations_error"), err, this.$scope.alerts.main))
+                .finally(() => {
+                    this.loading = false;
+                });
+        }
 });


### PR DESCRIPTION
### Requirements

## New domain transfert won't crash anymore

### Description of the Change

The progress bar object is not available right after operation creation, which resulted in an error message in the manager. The error message won't display anymore.