### PR TITLE
Fix/senegal menu not working

### DIFF
--- a/client/app/components/manager-navbar/manager-navbar.module.js
+++ b/client/app/components/manager-navbar/manager-navbar.module.js
@@ -10,7 +10,7 @@ angular
         function setMenuItemssToOtherUniverses (currentUser) {
             const universeMenuItems = Object.keys(constants.MANAGER_URLS)
                 .map((universeName) => ({
-                    icon: universeName === "labs" ? "fa fa-flask fs24" : null,
+                    icon: universeName === "labs" ? "fa fa-flask" : null,
                     label: universeName === "labs" ? null : translator.tr(`universe_univers-${universeName}_name`),
                     title: translator.tr(`universe_univers-${universeName}_name`),
                     universe: universeName,


### PR DESCRIPTION
### Requirements

## Menu now displays for Senegal
The top navbar wouldn't display in case where no guides were given to the subsidiary. Now the navbar is much more sturdy.