### PR TITLE
style(hosting): handle and translate cryptic error message from the backend

### DIFF
--- a/client/app/hosting/ssl/order/hosting-order-ssl.controller.js
+++ b/client/app/hosting/ssl/order/hosting-order-ssl.controller.js
@@ -63,7 +63,7 @@ angular.module("App").controller(
                         return rtn;
                     })
                     .catch((err) => {
-                        this.Alerter.alertFromSWS(this.$scope.tr("hosting_dashboard_ssl_order_error"), err, this.$scope.alerts.main);
+                        this._handleSslError(err);
                         this.$scope.resetAction();
                     })
                     .finally(() => {
@@ -88,12 +88,20 @@ angular.module("App").controller(
 
                 this.Hosting.createSsl(this.$stateParams.productId, data.certificate, data.key, data.chain)
                     .then(() => this.Alerter.success(this.$scope.tr("hosting_dashboard_ssl_generate_success"), this.$scope.alerts.main))
-                    .catch((err) => this.Alerter.alertFromSWS(this.$scope.tr("hosting_dashboard_ssl_order_error"), err, this.$scope.alerts.main))
+                    .catch((err) => this._handleSslError(err))
                     .finally(() => {
                         this.$scope.loadSsl();
                         this.$scope.resetAction();
                     });
             }
+        }
+
+        _handleSslError (err) {
+            let message = this.$scope.tr("hosting_dashboard_ssl_order_error");
+            if (err.message === "No attached domain with ssl enabled or no attached domain that redirect on hosting IPs, please use hosting IPs in your domain zone") {
+                message += ` ${this.$scope.tr("hosting_dashboard_ssl_order_error_no_attached_domain", this.$scope.hosting.hostingIp)}`;
+            }
+            this.Alerter.alertFromSWS(message, err, this.$scope.alerts.main);
         }
 
         isStepOneValid () {

--- a/client/app/resources/i18n/hosting/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/hosting/Messages_fr_FR.xml
@@ -190,6 +190,7 @@
    <translation id="hosting_dashboard_ssl_order_validation" qtlid="217665">Cliquez sur "Valider" pour créer votre bon de commande. Après validation du paiement, votre certificat SSL sera disponible sous 48 heures.</translation>
    <translation id="hosting_dashboard_ssl_order_success" qtlid="181266">La commande numéro <a href='{0}' target='_blank'>{1}</a> a bien été prise en compte.</translation>
    <translation id="hosting_dashboard_ssl_order_error" qtlid="217678">Une erreur est survenue lors de la commande d'un certificat SSL.</translation>
+   <translation id="hosting_dashboard_ssl_order_error_no_attached_domain">Vérifiez que le nom de domaine associé à votre hébergement redirige bien vers l'adresse IP ({0}) de ce dernier.</translation>
    <translation id="hosting_dashboard_ssl_order_payable" qtlid="298877">Certificat payant</translation>
    <translation id="hosting_dashboard_ssl_order_free" qtlid="298890">Certificat gratuit (Let's encrypt)</translation>
    <translation id="hosting_dashboard_ssl_order_a_certificate" qtlid="382141">Commander un certificat payant</translation>


### PR DESCRIPTION
An error message from the backend is shown when a user tries to order an SSL certificate while the hosting is not configured correctly. This message is cryptic and not translated.

This change allows a translation of that message (while keeping the original one in parentheses) and helps the user understand what he/she needs to do.

This is obviously a rather dirty and temporary fix. We need a better error message from the backend.