### PR TITLE
Feat/ Suggest to add an authorised IP when creating a DBaaS

### DIFF
--- a/client/app/private-database/database/add/private-database-database-add.controller.js
+++ b/client/app/private-database/database/add/private-database-database-add.controller.js
@@ -18,7 +18,10 @@ angular.module("App").controller(
             if (this.$scope.isDBaaS()) {
                 this.checkAuthorizedIp()
                     .then((hasAuthorizedIp) => {
+                        // if there are no ip configured,
+                        // we check the box to suggest the user to add an ip
                         this.model.addIp = !hasAuthorizedIp;
+
                         this.hasAuthorizedIp = hasAuthorizedIp;
                     });
             }

--- a/client/app/private-database/database/add/private-database-database-add.controller.js
+++ b/client/app/private-database/database/add/private-database-database-add.controller.js
@@ -15,11 +15,13 @@ angular.module("App").controller(
         $onInit () {
             this.productId = this.$stateParams.productId;
 
-            this.checkAuthorizedIp()
-                .then((hasAuthorizedIp) => {
-                    this.model.addIp = !hasAuthorizedIp;
-                    this.hasAuthorizedIp = hasAuthorizedIp;
-                });
+            if (this.$scope.isDBaaS()) {
+                this.checkAuthorizedIp()
+                    .then((hasAuthorizedIp) => {
+                        this.model.addIp = !hasAuthorizedIp;
+                        this.hasAuthorizedIp = hasAuthorizedIp;
+                    });
+            }
 
             this.model = {
                 addUser: false,

--- a/client/app/private-database/database/add/private-database-database-add.html
+++ b/client/app/private-database/database/add/private-database-database-add.html
@@ -119,6 +119,41 @@
                     </div>
                 </div>
             </form>
+
+            <form class="form-horizontal" name="privateDatabaseAddAuthorizedIpForm" ng-if="!addBddCtrl.hasAuthorizedIp">
+                <!-- ADD AUTHORIZED IP -->
+
+                <div class="oui-checkbox d-inline-block">
+                    <input type="checkbox" class="oui-checkbox__input" name="bddAddIpCheckbox" id="bddAddIpCheckbox"
+                           data-ng-model="addBddCtrl.model.addIp">
+                    <label class="oui-checkbox__label-container" for="bddAddIpCheckbox">
+                        <span class="oui-checkbox__label"
+                              data-i18n-static="privateDatabase_add_authorized_ip"></span>
+                        <span class="oui-checkbox__icon">
+                            <span class="oui-icon oui-icon-checkbox-unchecked" aria-hidden="true"></span>
+                            <span class="oui-icon oui-icon-checkbox-checked" aria-hidden="true"></span>
+                            <span class="oui-icon oui-icon-checkbox-checkmark" aria-hidden="true"></span>
+                        </span>
+                    </label>
+                </div>
+
+                <div class="alert alert-warning help-block mt-3" data-ng-if="addBddCtrl.model.addIp" data-i18n-static="privateDatabase_add_authorized_ip_explanation"></div>
+
+                <div class="mt-5" data-ng-if="addBddCtrl.model.addIp">
+                    <div class="form-group" data-ng-class="{'has-error': privateDatabaseAddAuthorizedIpForm.bddAddIp.$dirty && !addBddCtrl.isIpValid(addBddCtrl.model.ip.value)}">
+                        <label class="control-label col-md-4 required" for="bddAddIp"
+                               data-i18n-static="privateDatabase_modale_whitelist_add_ip"></label>
+                        <div class="col-md-8">
+                            <input type="text" class="form-control" name="bddAddIp" id="bddAddIp" autocomplete="off" required
+                                   data-ng-model="addBddCtrl.model.ip.value">
+                             <div class="alert alert-info help-block mt-3" id="bddIpHelp" role="alert"
+                                  data-i18n-static="privateDatabase_modale_whitelist_add_ip_tooltip"
+                                  data-ng-class="{'alert-danger': privateDatabaseAddAuthorizedIpForm.bddAddIp.$dirty && !addBddCtrl.isIpValid(addBddCtrl.model.ip.value)}">
+                             </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/client/app/private-database/database/add/private-database-database-add.html
+++ b/client/app/private-database/database/add/private-database-database-add.html
@@ -120,7 +120,7 @@
                 </div>
             </form>
 
-            <form class="form-horizontal" name="privateDatabaseAddAuthorizedIpForm" ng-if="!addBddCtrl.hasAuthorizedIp">
+            <form class="form-horizontal" name="privateDatabaseAddAuthorizedIpForm" ng-if="isDBaaS() && !addBddCtrl.hasAuthorizedIp">
                 <!-- ADD AUTHORIZED IP -->
 
                 <div class="oui-checkbox d-inline-block">

--- a/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
@@ -303,6 +303,10 @@
    <translation id="privateDatabase_add_bdd_new_user_password_confirm" qtlid="300539">Confirmer le mot de passe</translation>
    <translation id="privateDatabase_add_bdd_new_user_password_tooltip" qtlid="300552">Entre 8 et 31 caractères, au moins une lettre majuscule, une lettre minuscule et un chiffre, doit être composé uniquement de chiffres et de lettres</translation>
 
+   <translation id="privateDatabase_add_authorized_ip">Ajouter une adresse IP autorisée</translation>
+   <translation id="privateDatabase_add_authorized_ip_explanation">Vous n'avez pas encore d'adresse IP autorisée à accéder à vos bases de données. Entrez ici l'adresse IP du serveur auquel vous souhaitez donner accès à vos bases.</translation>
+   <translation id="privateDatabase_add_authorized_ip_description">Accès initial à la base de données</translation>
+
    <translation id="privateDatabase_restore_bdd_application" qtlid="404707">Veuillez dans un premier temps recréer celle-ci dans l'onglet de gestion de vos bases de données.</translation>
    <translation id="privateDatabase_restore_bdd_close" qtlid="4670">Fermer</translation>
    <translation id="privateDatabase_restore_bdd_confirm" qtlid="272290">Souhaitez-vous restaurer la sauvegarde du <strong>{0}</strong> sur la base de données <strong>{1}</strong> ?</translation>


### PR DESCRIPTION
It's not always obvious for the user that when creating a database (cloudDB) for the first time, the server won't be able to access it until an IP has been whitelisted.

With this change, we detect when there are no whitelisted IPs yet, and directly ask for one in the database creation form.

The user can always uncheck this suggestion if he/she doesn't want to be bothered with this for now, and do it manually later on.

We don't suggest this anymore when at least one IP has been configured.