### PR TITLE
Feat: display database certificate

### DIFF
--- a/client/app/private-database/database/certificate/private-database-database-certificate.controller.js
+++ b/client/app/private-database/database/certificate/private-database-database-certificate.controller.js
@@ -1,0 +1,20 @@
+angular
+    .module("App")
+    .controller("PrivateDatabaseCertificateCtrl", class PrivateDatabaseCertificateCtrl {
+
+        constructor ($scope, $stateParams, Alerter, PrivateDatabase) {
+            this.$scope = $scope;
+            this.$stateParams = $stateParams;
+            this.alerter = Alerter;
+            this.privateDatabaseService = PrivateDatabase;
+        }
+
+        $onInit () {
+            this.productId = this.$stateParams.productId;
+            this.database = this.$scope.currentActionData;
+
+            this.model = {
+                certificate: _.get(this.database, "tlsCa", null)
+            };
+        }
+});

--- a/client/app/private-database/database/certificate/private-database-database-certificate.html
+++ b/client/app/private-database/database/certificate/private-database-database-certificate.html
@@ -1,7 +1,6 @@
 <div data-ng-controller="PrivateDatabaseCertificateCtrl as certificateCtrl">
 
     <div data-wizard
-         data-wizard-bread-crumb
          data-wizard-on-cancel="resetAction"
          data-wizard-cancel-button-text="i18n.privateDatabase_modale_oom_close_button"
          data-wizard-hide-confirm-button
@@ -11,7 +10,7 @@
             <div class="form-group">
                 <textarea type="text" rows="10"
                           class="form-control" id="certificateTextArea"
-                          readonly ng-value="certificateCtrl.database.tlsCa"></textarea>
+                          readonly data-ng-value="certificateCtrl.database.tlsCa"></textarea>
             </div>
         </div>
     </div>

--- a/client/app/private-database/database/certificate/private-database-database-certificate.html
+++ b/client/app/private-database/database/certificate/private-database-database-certificate.html
@@ -8,7 +8,7 @@
 
         <div data-wizard-step>
             <div class="form-group">
-                <textarea type="text" rows="10"
+                <textarea type="text" rows="20" style="font-family: monospace;font-size: 0.7em;line-height: 1.0;font-weight: normal;"
                           class="form-control" id="certificateTextArea"
                           readonly data-ng-value="certificateCtrl.database.tlsCa"></textarea>
             </div>

--- a/client/app/private-database/database/certificate/private-database-database-certificate.html
+++ b/client/app/private-database/database/certificate/private-database-database-certificate.html
@@ -1,0 +1,18 @@
+<div data-ng-controller="PrivateDatabaseCertificateCtrl as certificateCtrl">
+
+    <div data-wizard
+         data-wizard-bread-crumb
+         data-wizard-on-cancel="resetAction"
+         data-wizard-cancel-button-text="i18n.privateDatabase_modale_oom_close_button"
+         data-wizard-hide-confirm-button
+         data-wizard-title="i18n.privateDatabase_dashboard_certificate">
+
+        <div data-wizard-step>
+            <div class="form-group">
+                <textarea type="text" rows="10"
+                          class="form-control" id="certificateTextArea"
+                          readonly ng-value="certificateCtrl.database.tlsCa"></textarea>
+            </div>
+        </div>
+    </div>
+</div>

--- a/client/app/private-database/private-database.service.js
+++ b/client/app/private-database/private-database.service.js
@@ -123,6 +123,12 @@ angular.module("services").service(
                     database.capabilities = _.mapKeys(database.capabilities, (capability) => capability.object);
                     return database;
                 })
+                .then((database) => {
+                    // we don't have any other certificate types right now
+                    // and the API doesn't have this field
+                    database.certificateType = "TLS";
+                    return database;
+                })
                 .catch((err) => this.$q.reject(err.data));
         }
 

--- a/client/app/private-database/private-database.service.js
+++ b/client/app/private-database/private-database.service.js
@@ -126,7 +126,7 @@ angular.module("services").service(
                 .then((database) => {
                     // we don't have any other certificate types right now
                     // and the API doesn't have this field
-                    database.certificateType = "TLS";
+                    database.certificateType = "TLS CA";
                     return database;
                 })
                 .catch((err) => this.$q.reject(err.data));

--- a/client/app/private-database/state/private-database-state.html
+++ b/client/app/private-database/state/private-database-state.html
@@ -247,9 +247,7 @@
                                                 <div class="ml-auto my-auto">
                                                     <button class="btn btn-default my-auto ml-auto text-wrap" type="button" title="{{::i18n.privateDatabase_see_certificate}}"
                                                             data-i18n-static="privateDatabase_dashboard_see_certificate"
-                                                            data-ng-click="setAction('database/certificate/private-database-database-certificate', stateCtrl.database)"
-                                                            data-ng-disabled="taskState.lockAction"
-                                                            data-ng-if="!stateCtrl.isExpired">
+                                                            data-ng-click="setAction('database/certificate/private-database-database-certificate', stateCtrl.database)">
                                                     </button>
                                                 </div>
                                             </div>

--- a/client/app/private-database/state/private-database-state.html
+++ b/client/app/private-database/state/private-database-state.html
@@ -236,6 +236,25 @@
                                             <span data-ng-bind="::stateCtrl.database.port"></span>
                                         </div>
                                     </li>
+                                    <li class="oui-tile__item" ng-if="stateCtrl.database.tlsCa">
+                                        <div class="oui-tile__definition">
+                                            <div class="d-flex w-100">
+                                                <div>
+                                                    <strong class="d-block"
+                                                            data-i18n-static="privateDatabase_dashboard_certificate"></strong>
+                                                    <span data-ng-bind="::stateCtrl.database.certificateType"></span>
+                                                </div>
+                                                <div class="ml-auto my-auto">
+                                                    <button class="btn btn-default my-auto ml-auto text-wrap" type="button" title="{{::i18n.privateDatabase_see_certificate}}"
+                                                            data-i18n-static="privateDatabase_dashboard_see_certificate"
+                                                            data-ng-click="setAction('database/certificate/private-database-database-certificate', stateCtrl.database)"
+                                                            data-ng-disabled="taskState.lockAction"
+                                                            data-ng-if="!stateCtrl.isExpired">
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
                                     <li class="oui-tile__item">
                                         <div class="oui-tile__definition">
                                             <strong class="d-block"

--- a/client/app/private-database/state/private-database-state.html
+++ b/client/app/private-database/state/private-database-state.html
@@ -236,12 +236,29 @@
                                             <span data-ng-bind="::stateCtrl.database.port"></span>
                                         </div>
                                     </li>
+                                    <li class="oui-tile__item">
+                                        <div class="oui-tile__definition">
+                                            <strong class="d-block"
+                                                    data-i18n-static="privateDatabase_tab_USER"></strong>
+                                            <button class="btn btn-link p-0" type="button"
+                                                    data-i18n-static="privateDatabase_dashboard_admin_informations_users"
+                                                    data-ng-click="setSelectedTab('USER')">
+                                            </button>
+                                        </div>
+                                    </li>
                                     <li class="oui-tile__item" ng-if="stateCtrl.database.tlsCa">
                                         <div class="oui-tile__definition">
                                             <div class="d-flex w-100">
                                                 <div>
-                                                    <strong class="d-block"
+                                                    <div class="d-block">
+                                                        <strong
                                                             data-i18n-static="privateDatabase_dashboard_certificate"></strong>
+                                                        <span class="fa fa-info-circle"
+                                                              aria-hidden="true"
+                                                              data-uib-tooltip="{{tr('privateDatabase_dashboard_certificate_tooltip')}}"
+                                                              data-tooltip-append-to-body="true"
+                                                              data-tooltip-placement="top"></span>
+                                                    </div>
                                                     <span data-ng-bind="::stateCtrl.database.certificateType"></span>
                                                 </div>
                                                 <div class="ml-auto my-auto">
@@ -251,16 +268,6 @@
                                                     </button>
                                                 </div>
                                             </div>
-                                        </div>
-                                    </li>
-                                    <li class="oui-tile__item">
-                                        <div class="oui-tile__definition">
-                                            <strong class="d-block"
-                                                    data-i18n-static="privateDatabase_tab_USERS"></strong>
-                                            <button class="btn btn-link p-0" type="button"
-                                                    data-i18n-static="privateDatabase_dashboard_admin_informations_users"
-                                                    data-ng-click="setSelectedTab('USER')">
-                                            </button>
                                         </div>
                                     </li>
                                 </ul>

--- a/client/app/private-database/state/private-database-state.html
+++ b/client/app/private-database/state/private-database-state.html
@@ -175,7 +175,7 @@
                                     <li class="oui-tile__item">
                                         <div class="oui-tile__definition">
                                             <strong class="d-block"
-                                                    data-i18n-static="privateDatabase_tab_USERS"></strong>
+                                                    data-i18n-static="privateDatabase_tab_USER"></strong>
                                             <button class="btn btn-link p-0" type="button"
                                                     data-i18n-static="privateDatabase_dashboard_admin_informations_users"
                                                     data-ng-click="setSelectedTab('USER')">

--- a/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
@@ -48,6 +48,7 @@
    <translation id="privateDatabase_dashboard_port_docker" qtlid="262947">Port SFTP</translation>
    <translation id="privateDatabase_dashboard_port" qtlid="9034">Port</translation>
    <translation id="privateDatabase_dashboard_certificate">Certificat</translation>
+   <translation id="privateDatabase_dashboard_certificate_tooltip">Le certificat n'est pas obligatoire pour réaliser la connexion à votre instance. Celui-ci est par contre nécessaire si vous désirez chiffrer la connexion vers celle-ci.</translation>
    <translation id="privateDatabase_dashboard_see_certificate">Voir le certificat</translation>
    <translation id="privateDatabase_dashboard_service_hosting_more" qtlid="325924">Voir la liste</translation>
    <translation id="privateDatabase_dashboard_service_hosting_linked" qtlid="444456">Hébergement web lié</translation>

--- a/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
@@ -47,6 +47,8 @@
    <translation id="privateDatabase_dashboard_port_legacy" qtlid="254843">Port FTP</translation>
    <translation id="privateDatabase_dashboard_port_docker" qtlid="262947">Port SFTP</translation>
    <translation id="privateDatabase_dashboard_port" qtlid="9034">Port</translation>
+   <translation id="privateDatabase_dashboard_certificate">Certificat</translation>
+   <translation id="privateDatabase_dashboard_see_certificate">Voir le certificat</translation>
    <translation id="privateDatabase_dashboard_service_hosting_more" qtlid="325924">Voir la liste</translation>
    <translation id="privateDatabase_dashboard_service_hosting_linked" qtlid="444456">Hébergement web lié</translation>
    <translation id="privateDatabase_dashboard_service_hosting_linked_none" qtlid="30646">Aucun</translation>


### PR DESCRIPTION
Add a button that allows the user to see and copy/paste his TLS certificate in the database information page.