### PR TITLE
Feat(me-alerts): add new parameter to 2API call

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -86,7 +86,7 @@
     "ovh-angular-tail-logs": "^1.1.1",
     "angular-translate-loader-static-files": "^2.15.2",
     "ovh-angular-otrs": "^3.0.1",
-    "ovh-api-services": "^2.0.1",
+    "ovh-api-services": "^2.1.9",
     "ovh-angular-toaster": "^0.8.0",
     "ovh-jquery-ui-draggable-ng": "^0.0.5",
     "angular-resource": "^1.6.6",
@@ -111,7 +111,7 @@
     "ovh-angular-proxy-request": "^0.1.0",
     "angular-ui-router": "^0.4.2",
     "animate.css": "~3.5.0",
-    "ovh-api-services": "^2.0.0"
+    "ovh-api-services": "^2.1.9"
   },
   "private": true
 }

--- a/client/app/app.controller.js
+++ b/client/app/app.controller.js
@@ -1,7 +1,7 @@
 angular.module("App").controller(
     "AppCtrl",
     class AppCtrl {
-        constructor ($scope, $rootScope, $timeout, constants, incident, User, translator) {
+        constructor ($scope, $rootScope, $timeout, constants, incident, User, translator, OvhApiMeAlertsAapi) {
             this.$scope = $scope;
             this.$rootScope = $rootScope;
             this.$timeout = $timeout;
@@ -9,6 +9,7 @@ angular.module("App").controller(
             this.incident = incident;
             this.translator = translator;
             this.User = User;
+            this.ovhApiMeAlertsAapi = OvhApiMeAlertsAapi;
         }
 
         $onInit () {
@@ -38,7 +39,11 @@ angular.module("App").controller(
                 this.$rootScope.managerPreloadHide += " manager-preload-hide";
             });
 
-            this.User.getUserAlerts().then((alerts) => {
+            this.ovhApiMeAlertsAapi.query({
+                lang: this.translator.getLanguage(),
+                target: this.constants.target,
+                universe: this.constants.UNIVERS.toUpperCase()
+            }).$promise.then((alerts) => {
                 if (alerts && alerts.length) {
                     const messages = [];
 

--- a/client/app/components/user/user.service.js
+++ b/client/app/components/user/user.service.js
@@ -74,16 +74,6 @@ angular.module("services").service("User", [
                 return constants.urls.managerv3.FR;
             });
 
-        this.getUserAlerts = () =>
-            $http
-                .get("/me/alerts", {
-                    serviceType: "aapi",
-                    params: {
-                        target: constants.target
-                    }
-                })
-                .then((response) => response.data);
-
         this.getCreditCards = () =>
             $http.get("apiv6/me/paymentMean/creditCard").then((response) => {
                 const queries = response.data.map(this.getCreditCard);


### PR DESCRIPTION
Add current manager language and universe to 2API me/alerts call. The new version of me-alerts who will soon be deployed will provide some messages already translated.

### Requirements

The code can be merge with or without new version of the 2api in place. Sooner the better, this will avoid modifying each manager if a new message is return by me-alerts.

### Description of the Change

The same modification is done for each manager, the current language of the manager is can change despite /me and subsidiary.
