### PR TITLE
Show the right database backends available

### DIFF
--- a/client/app/hosting/database/hosting-database.service.js
+++ b/client/app/hosting/database/hosting-database.service.js
@@ -306,7 +306,7 @@ angular
          * @param {number} ram
          * @param {string} version
          */
-        activeDatabasePrivate (serviceName, ram, version) {
+        activateDatabasePrivate (serviceName, ram, version) {
             return this.OvhHttp.post(`/hosting/web/${serviceName}/activatePrivateDatabase`, {
                 rootPath: "apiv6",
                 data: {

--- a/client/app/hosting/database/private-activation/database-private-activation.controller.js
+++ b/client/app/hosting/database/private-activation/database-private-activation.controller.js
@@ -33,7 +33,7 @@ angular.module("App").controller("HostingDatabasePrivateActiveCtrl", ($scope, $r
 
     function getAvailableVersions (models) {
         const types = models.models["hosting.PrivateDatabase.OrderableVersionEnum"].enum;
-        return temporarilyFilterTypesUntilTheyAreOfficiallyReleased(types, ["mongodb_3.4", "redis_3.2"]);
+        return temporarilyFilterTypesUntilTheyAreOfficiallyReleased(types, ["mongodb_3.4"]);
     }
 
     function temporarilyFilterTypesUntilTheyAreOfficiallyReleased (types, restrictedList) {

--- a/client/app/hosting/database/private-activation/database-private-activation.controller.js
+++ b/client/app/hosting/database/private-activation/database-private-activation.controller.js
@@ -3,7 +3,7 @@ angular.module("App").controller("HostingDatabasePrivateActiveCtrl", ($scope, $r
 
     $scope.hosting = $scope.currentActionData;
 
-    $scope.datas = {
+    $scope.data = {
         versions: []
     };
     $scope.loaders = {
@@ -19,8 +19,8 @@ angular.module("App").controller("HostingDatabasePrivateActiveCtrl", ($scope, $r
             $scope.loaders.versions = true;
             Hosting.getModels()
                 .then((models) => {
-                    $scope.datas.versions = models.models["hosting.PrivateDatabase.OrderableVersionEnum"].enum;
-                    $scope.choice.version = $scope.datas.versions.length === 1 ? $scope.datas.versions[0] : null;
+                    $scope.data.versions = getAvailableVersions(models);
+                    $scope.choice.version = $scope.data.versions.length === 1 ? $scope.data.versions[0] : null;
                 })
                 .catch((err) => {
                     Alerter.alertFromSWS($scope.tr("hosting_dashboard_database_versions_error", [$scope.entryToDelete]), _.get(err, "data", err), $scope.alerts.main);
@@ -29,6 +29,15 @@ angular.module("App").controller("HostingDatabasePrivateActiveCtrl", ($scope, $r
                     $scope.loaders.versions = false;
                 });
         }
+    }
+
+    function getAvailableVersions (models) {
+        const types = models.models["hosting.PrivateDatabase.OrderableVersionEnum"].enum;
+        return temporarilyFilterTypesUntilTheyAreOfficiallyReleased(types, ["mongodb_3.4", "redis_3.2"]);
+    }
+
+    function temporarilyFilterTypesUntilTheyAreOfficiallyReleased (types, restrictedList) {
+        return _.filter(types, (type) => !_.contains(restrictedList, type));
     }
 
     $scope.activeDatabase = function () {

--- a/client/app/hosting/database/private-activation/database-private-activation.controller.js
+++ b/client/app/hosting/database/private-activation/database-private-activation.controller.js
@@ -10,10 +10,14 @@ angular.module("App").controller(
             this.Alerter = Alerter;
             this.PrivateDatabase = PrivateDatabase;
 
+            this.$scope.activateDatabase = () => this.activateDatabase();
+        }
+
+        $onInit () {
             this.host = this.$scope.currentActionData;
             this.versions = [];
             this.loaders = {
-                versions: false
+                retrievingVersions: true
             };
             this.choice = {
                 ram: this.host.offerCapabilities.privateDatabases.length === 1 ?
@@ -21,38 +25,27 @@ angular.module("App").controller(
                 version: null
             };
 
-            this.$scope.activateDatabase = () => this.activateDatabase();
-        }
-
-        $onInit () {
-            if (!this.loaders.versions) {
-                this.loaders.versions = true;
-                this.PrivateDatabase.getAvailableOrderCapacities("classic")
-                    .then((capacities) => {
-                        this.versions = _.get(capacities, "version");
-                        this.choice.version = this.versions.length === 1 ? _.first(this.versions) : null;
-                    })
-                    .catch((err) => {
-                        this.Alerter.alertFromSWS(this.$scope.tr("hosting_dashboard_database_versions_error",
-                                                                 [this.$scope.entryToDelete]),
-                                                  _.get(err, "data", err),
-                                                  this.$scope.alerts.main);
-                    })
-                    .finally(() => {
-                        this.loaders.versions = false;
-                    });
-            }
+            this.PrivateDatabase.getAvailableOrderCapacities("classic")
+                .then((capacities) => {
+                    this.versions = _.get(capacities, "version");
+                    this.choice.version = this.versions && this.versions.length === 1 ? _.first(this.versions) : null;
+                })
+                .catch((err) => {
+                    this.Alerter.alertFromSWS(this.$scope.tr("hosting_dashboard_database_versions_error",
+                                                             [this.$scope.entryToDelete]),
+                                              _.get(err, "data", err),
+                                              this.$scope.alerts.main);
+                })
+                .finally(() => {
+                    this.loaders.retrievingVersions = false;
+                });
         }
 
         activateDatabase () {
-            if (this.loaders.versions) {
-                return;
-            }
-
-            this.loaders.versions = true;
-            this.HostingDatabase.activateDatabasePrivate(this.$stateParams.productId,
-                                                         this.choice.ram.quota.value,
-                                                         this.choice.version)
+            return this.HostingDatabase
+                .activateDatabasePrivate(this.$stateParams.productId,
+                                         this.choice.ram.quota.value,
+                                         this.choice.version)
                 .then(() => {
                     this.$rootScope.$broadcast("hosting.database.sqlPrive");
                     this.Alerter.success(this.$scope.tr("hosting_dashboard_database_active_success"),

--- a/client/app/hosting/database/private-activation/database-private-activation.html
+++ b/client/app/hosting/database/private-activation/database-private-activation.html
@@ -37,7 +37,7 @@
                             <div class="oui-select">
                                 <select class="oui-select__input" id="databaseVersion" name="databaseVersion"
                                         data-ng-model="choice.version"
-                                        data-ng-options="version for (key, version) in datas.versions track by version">
+                                        data-ng-options="version for (key, version) in data.versions track by version">
                                     <option value="" disabled
                                             data-i18n-static="select_placeholder"></option>
                                 </select>

--- a/client/app/hosting/database/private-activation/database-private-activation.html
+++ b/client/app/hosting/database/private-activation/database-private-activation.html
@@ -1,19 +1,19 @@
-<div data-ng-controller="HostingDatabasePrivateActiveCtrl">
+<div data-ng-controller="HostingDatabasePrivateActiveCtrl as ctrl">
     <div data-wizard
          data-wizard-on-cancel="resetAction"
-         data-wizard-on-finish="activeDatabase"
+         data-wizard-on-finish="activateDatabase"
          data-wizard-title="i18n.hosting_dashboard_database_active_title">
 
         <div data-wizard-step
-             data-wizard-step-valid="!loaders.versions">
+             data-wizard-step-valid="!ctrl.loaders.versions">
 
             <p data-i18n-static="hosting_dashboard_database_active_info"></p>
 
-            <div class="text-center" data-ng-if="loaders.versions">
+            <div class="text-center" data-ng-if="ctrl.loaders.versions">
                 <oui-loader inline="true"></oui-loader>
             </div>
 
-            <div data-ng-if="!loaders.versions">
+            <div data-ng-if="!ctrl.loaders.versions">
                 <form class="form-horizontal">
                     <div class="form-group">
                         <label class="control-label col-md-3" for="databaseRam"
@@ -21,8 +21,8 @@
                         <div class="col-md-6">
                             <div class="oui-select">
                                 <select class="oui-select__input" id="databaseRam" name="databaseRam"
-                                        data-ng-model="choice.ram"
-                                        data-ng-options="(ram.quota.value + ' ' + ram.quota.unit) for ram in hosting.offerCapabilities.privateDatabases">
+                                        data-ng-model="ctrl.choice.ram"
+                                        data-ng-options="(ram.quota.value + ' ' + ram.quota.unit) for ram in ctrl.host.offerCapabilities.privateDatabases">
                                     <option value="" disabled
                                             data-i18n-static="select_placeholder"></option>
                                 </select>
@@ -36,8 +36,8 @@
                         <div class="col-md-6">
                             <div class="oui-select">
                                 <select class="oui-select__input" id="databaseVersion" name="databaseVersion"
-                                        data-ng-model="choice.version"
-                                        data-ng-options="version for (key, version) in data.versions track by version">
+                                        data-ng-model="ctrl.choice.version"
+                                        data-ng-options="version for (key, version) in ctrl.versions track by version">
                                     <option value="" disabled
                                             data-i18n-static="select_placeholder"></option>
                                 </select>

--- a/client/app/hosting/database/private-activation/database-private-activation.html
+++ b/client/app/hosting/database/private-activation/database-private-activation.html
@@ -5,15 +5,15 @@
          data-wizard-title="i18n.hosting_dashboard_database_active_title">
 
         <div data-wizard-step
-             data-wizard-step-valid="!ctrl.loaders.versions">
+             data-wizard-step-valid="!ctrl.choice.version || !ctrl.choice.ram">
 
             <p data-i18n-static="hosting_dashboard_database_active_info"></p>
 
-            <div class="text-center" data-ng-if="ctrl.loaders.versions">
+            <div class="text-center" data-ng-if="ctrl.loaders.retrievingVersions">
                 <oui-loader inline="true"></oui-loader>
             </div>
 
-            <div data-ng-if="!ctrl.loaders.versions">
+            <div data-ng-if="!ctrl.loaders.retrievingVersions">
                 <form class="form-horizontal">
                     <div class="form-group">
                         <label class="control-label col-md-3" for="databaseRam"


### PR DESCRIPTION
We were not using the right API endpoint to know what were the database types available to purchase when going to Hosting (perf only) > Private SQL > Activate.

I refactored the controller to a class and hit the right endpoint.
Now every time the API staff pushes changes or new database backends, they are available to purchase.

(don't mind the branch name, Redis is prodded now)