### PR TITLE
fix(privatedb.metrics) : Use local format for time display

### DIFF
--- a/client/app/private-database/metrics/private-database-metrics.constant.js
+++ b/client/app/private-database/metrics/private-database-metrics.constant.js
@@ -55,6 +55,11 @@ angular.module("App").constant("PRIVATE_DATABASE_METRICS", {
                     gridLines: {
                         drawBorder: true,
                         display: false
+                    },
+                    time: {
+                        displayFormats: {
+                            hour: "LT"
+                        }
                     }
                 }]
             }


### PR DESCRIPTION
## Adapt time scale to local format depending on user's language


### Description of the Change

Before : time was always in US format
Now : time displays depending on user's selected language 
