### PR TITLE
 fix(privatedb): Add translation for correct version label display

### DIFF
--- a/client/app/private-database/order/sql-database-order-controller.js
+++ b/client/app/private-database/order/sql-database-order-controller.js
@@ -175,6 +175,7 @@ angular.module("App").controller(
             this.model.dbPack = null;
             this.model.hosting = null;
             this.getDuration();
+            this.resetOrder();
         }
 
         /*
@@ -183,6 +184,7 @@ angular.module("App").controller(
         getDuration () {
             this.loading.durations = true;
             this.model.duration = null;
+            this.resetOrder();
             const selected = this.getData(this.model.type);
 
             return this[`getDurations${selected.key}`](selected).then((durations) => {
@@ -403,6 +405,10 @@ angular.module("App").controller(
 
         isStart () {
             return this.getData(this.model.type).key === "start";
+        }
+
+        resetOrder () {
+            this.order = null;
         }
     }
 );

--- a/client/app/private-database/order/sql-database-order.html
+++ b/client/app/private-database/order/sql-database-order.html
@@ -158,6 +158,7 @@
                                  data-ng-repeat="duration in sqlOrderCtrl.getData(sqlOrderCtrl.model.type).durations track by $index">
                                 <input type="radio" class="oui-radio__input" name="durationRadio[$index]" id="durationRadio-{{$index}}" required
                                        data-ng-click="contractsValidated = false"
+                                       data-ng-change="sqlOrderCtrl.resetOrder()"
                                        data-ng-disabled="sqlOrderCtrl.loading.prices || sqlOrderCtrl.durations.length === 1"
                                        data-ng-model="sqlOrderCtrl.model.duration"
                                        data-ng-value="duration.duration">

--- a/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/privateDatabase/Messages_fr_FR.xml
@@ -7,6 +7,7 @@
    <translation id="privateDatabase_dashboard_quota" qtlid="258951">L'espace total utilisé est : {0}</translation>
    <translation id="privateDatabase_dashboard_version" qtlid="34210">Version</translation>
    <translation id="privateDatabase_dashboard_version_mariadb_101" qtlid="444430">MariaDB 10.1</translation>
+   <translation id="privateDatabase_dashboard_version_mariadb_102">MariaDB 10.2</translation>   
    <translation id="privateDatabase_dashboard_version_mysql_41" qtlid="215572">MySQL 4.1</translation>
    <translation id="privateDatabase_dashboard_version_mysql_50" qtlid="215585">MySQL 5.0</translation>
    <translation id="privateDatabase_dashboard_version_mysql_51" qtlid="215598">MySQL 5.1</translation>


### PR DESCRIPTION
## Add translation so the database version label displays in the correct format


### Description of the Change

Before: label was displayed without being formatted
Now: label displays in the right format