### PR TITLE
chore: bump version of ovh-ui-kit-bs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -82,7 +82,7 @@
     "ovh-angular-responsive-tabs": "^3.1.4",
     "ovh-ui-angular": "^2.7.x",
     "ovh-ui-kit": "^2.7.x",
-    "ovh-ui-kit-bs": "^1.0.x",
+    "ovh-ui-kit-bs": "~1.1.x",
     "ovh-angular-tail-logs": "^1.1.1",
     "angular-translate-loader-static-files": "^2.15.2",
     "ovh-angular-otrs": "^3.0.1",

--- a/client/app/css/source.less
+++ b/client/app/css/source.less
@@ -1,12 +1,10 @@
-@import "bower_components/ovh-ui-kit/packages/oui-color/_constants";
-
+@rem-base: rem-base(10px);
 @bs-path: "bower_components/bootstrap";
 @oui-path: "bower_components/ovh-ui-kit";
 
+// Vendors
+@import "@{oui-path}/packages/oui/stylekit";
 @import "bower_components/ovh-ui-kit-bs/src/ovh-ui-kit-bs";
-
-@oui-icon-dist-folder: "../bower_components/ovh-ui-kit/dist/icons";
-
 @import "bower_components/ovh-angular-actions-menu/less/ovh-angular-actions-menu";
 @import "bower_components/ovh-angular-otrs/dist/ovh-angular-otrs";
 @import 'bower_components/ovh-manager-webfont/dist/less/ovh-font';
@@ -45,5 +43,10 @@
 @import "../components/manager-preload/manager-preload";
 @import "../components/sidebar-menu/sidebar-menu";
 
+// Paths for Icons & Fonts
+@icon-font-path: "../bower_components/bootstrap/fonts/";
+@oui-icon-dist-folder: "../bower_components/ovh-ui-kit/dist/icons";
+@oui-font-source-sans-pro-folder: "../bower_components/ovh-ui-kit/packages/oui-typography/fonts/source-sans-pro";
 @ovh-font-path: "../bower_components/ovh-manager-webfont/dist/fonts";
+
 @ovh-universe-color: @oui-color-jungle;


### PR DESCRIPTION
Update ovh-ui-kit-bs to v1.1.0 (see https://github.com/ovh-ux/ovh-ui-kit-bs/pull/43)