### PR TITLE
chore: git push on post-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "commit": "npm-scripts-config commit",
     "commitmsg": "npm-scripts-config commitmsg",
     "version": "npm-scripts-config version && npm-bower-sync-ver && git add bower.json",
+    "postversion": "git push && git push --tags",
     "preview-changelog": "npm-scripts-config preview-changelog"
   },
   "private": true,


### PR DESCRIPTION
Before git push and git push --tags was done by grunt-bump but since it has been removed we need to do it by ourself.