### PR TITLE
style(tooltip): Create selector to prevent line break removal

### DIFF
--- a/client/app/css/less/common/tooltip.less
+++ b/client/app/css/less/common/tooltip.less
@@ -2,6 +2,10 @@
     text-align: left;
 }
 
+.tooltip.pre-line {
+    white-space: pre-line;
+}
+
 .as-superscript {
     vertical-align: super;
 }


### PR DESCRIPTION
## Add selector to prevent line breaks from being removed in ui bs tooltips


### Description of the Change

Create selector that can be added as a tooltip-class to display line breaks 

Linked to PR : https://github.com/ovh-ux/ovh-module-office/pull/20