### PR TITLE
fix(navbar): language button position and format

### DIFF
--- a/client/app/components/user/session.service.js
+++ b/client/app/components/user/session.service.js
@@ -213,7 +213,7 @@ class SessionService {
             name: "languages",
             label: _(currentLanguage).get("name"),
             "class": "oui-navbar-menu_language",
-            title: _(currentLanguage).get("value").replace("_", "-"),
+            title: _(currentLanguage).get("value").split("_")[0].toUpperCase(),
             headerTitle: this.translator.tr("global_language"),
             subLinks: _(this.LANGUAGES)
                 .filter((language) => _(language).has("name", "value"))
@@ -426,8 +426,8 @@ class SessionService {
             // Set Internal Links
             if (user) {
                 baseNavbar.internalLinks = [
-                    this.getAssistanceMenu(user), // Assistance
                     this.getLanguageMenu(), // Language
+                    this.getAssistanceMenu(user), // Assistance
                     this.getUserMenu(user) // User
                 ];
             }


### PR DESCRIPTION
### fix navbar language item following CX guidelines : 

- change the position of language item in navbar
- change the display from "en-US" to "EN"

changes replicated in the 4 managers.