### PR TITLE
fix(cloudweb): hide statistics in cloudweb dashboard

### DIFF
--- a/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
+++ b/client/app/hosting/general-informations/GENERAL_INFORMATIONS.html
@@ -484,6 +484,9 @@
         </div>
     </div>
 
-    <h2 class="mt-5" data-i18n-static="hosting_dashboard_hosting_activities"></h2>
-    <div data-ng-include="'hosting/statistics/STATISTICS.html'"></div>
+    <div class="mt-5"
+         data-ng-if="!hosting.isCloudWeb">
+        <h2 data-i18n-static="hosting_dashboard_hosting_activities"></h2>
+        <div data-ng-include="'hosting/statistics/STATISTICS.html'"></div>
+    </div>
 </div>


### PR DESCRIPTION
## Hide statistics in cloudweb dashboard

### Description of the Change

Hide statistics in cloudweb dashboard, because this feature is not available.
