### PR TITLE
fix(cloudweb): display runtimes in external multisite creation

### DIFF
--- a/client/app/hosting/multisite/add/external/hosting-multisite-add-external.html
+++ b/client/app/hosting/multisite/add/external/hosting-multisite-add-external.html
@@ -57,6 +57,24 @@
         </div>
     </div>
 
+    <div class="form-group" data-ng-if="hosting.isCloudWeb">
+        <label class="control-label col-md-4" for="selectedRuntime" data-i18n-static="hosting_tab_DOMAINS_configuration_modify_step1_runtime"></label>
+        <div data-ng-if="loaders.runtimes">
+            <oui-spinner data-size="s"></oui-spinner>
+        </div>
+
+        <div class="col-md-8" data-ng-if="!loaders.runtimes">
+            <div class="oui-select oui-select_inline mb-0">
+                <select class="oui-select__input" id="selectedRuntime" required
+                        data-ng-model="selected.runtime"
+                        data-ng-options="runtime.name for runtime in model.runtimes track by runtime.name">
+                    <option value="" data-i18n-static="select_placeholder" disabled></option>
+                </select>
+                <span class="oui-icon oui-icon-chevron-down" aria-hidden="true"></span>
+            </div>
+        </div>
+    </div>
+
     <div class="form-group">
         <label class="control-label col-md-4" for="domainAttacheModeExternalFormSelectedIpv6"
                data-i18n-static="hosting_tab_DOMAINS_configuration_add_step2_mode_EXTERNAL_ipv6"></label>


### PR DESCRIPTION
## Display runtimes in external multisite creation

### Description of the Change

Allow the user to select the runtime in external multisite creation (cloudweb)