### PR TITLE
fix(*): order account link redirects to wront page

### DIFF
--- a/client/app/email-domain/email/account/migrate/email-domain-email-account-migrate.html
+++ b/client/app/email-domain/email/account/migrate/email-domain-email-account-migrate.html
@@ -134,15 +134,18 @@
                 </p>
                 <p data-ng-switch="ctrl.migrate.destinationService.type">
                     <span data-i18n-static="email_tab_modal_migrate_choose_another_service_or"></span>
-                    <a class="oui-link" href="/#/configuration/email_pro/{{ctrl.migrate.destinationService.name}}?tab=ACCOUNT"
+                    <a class="oui-link" 
+                        data-ui-sref="app.email-pro({productId: ctrl.migrate.destinationService.name, tab: 'ACCOUNT'})"
                         data-ng-switch-when="EMAIL PRO"
                         data-i18n-static="email_tab_modal_migrate_order_new_emails_button">
                     </a>
-                    <a class="oui-link" href="/#/configuration/exchange_hosted/{{ctrl.migrate.destinationService.name}}/{{ctrl.migrate.destinationService.name}}?tab=ACCOUNT"
+                    <a class="oui-link"
+                        data-ui-sref="app.microsoft.exchange.hosted({organization: ctrl.migrate.destinationService.name, productId: ctrl.migrate.destinationService.name, tab: 'ACCOUNT'})"
                         data-ng-switch-when="HOSTED EXCHANGE"
                         data-i18n-static="email_tab_modal_migrate_order_new_emails_button">
                     </a>
-                    <a class="oui-link" href="/#/configuration/exchange_dedicated/{{ctrl.migrate.destinationService.name}}/{{ctrl.migrate.destinationService.name}}?tab=ACCOUNT"
+                    <a class="oui-link"
+                        data-ui-sref="app.microsoft.exchange.dedicated({organization: ctrl.migrate.destinationService.name, productId: ctrl.migrate.destinationService.name, tab: 'ACCOUNT'})"
                         data-ng-switch-when="PRIVATE EXCHANGE"
                         data-i18n-static="email_tab_modal_migrate_order_new_emails_button">
                     </a>


### PR DESCRIPTION
order account link redirects to wront page for email pro, hosted exchange and private exchange

Closes MFRWW-616

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
order account link redirects to the wrong page

### Description of the Change
href used on <a> tag was redirecting to ovh.com instead of to the same origin. I have changed href to ng-ui-sref and this redirects to proper URL within same domain and url (same origin).

### Benefits
bug fixed

### Possible Drawbacks
none

### Applicable Issues
MFRWW-616
