### PR TITLE
chore(deps): bump ovh-ui-kit and ovh-ui-kit-bs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -79,9 +79,9 @@
     "angular-translate": "^2.15.1",
     "ovh-manager-webfont": "^1.0.1",
     "ovh-angular-responsive-tabs": "^4.0.0",
-    "ovh-ui-angular": "~2.16.x",
-    "ovh-ui-kit": "~2.16.x",
-    "ovh-ui-kit-bs": "~1.2.x",
+    "ovh-ui-angular": "~2.17.x",
+    "ovh-ui-kit": "~2.17.x",
+    "ovh-ui-kit-bs": "~1.3.x",
     "ovh-angular-tail-logs": "^1.1.1",
     "angular-translate-loader-static-files": "^2.15.2",
     "ovh-angular-otrs": "^6.0.1",
@@ -112,8 +112,8 @@
     "angular-ui-router": "^1.0.0",
     "animate.css": "~3.5.0",
     "ng-at-internet": "~3.0.0",
-    "ovh-ui-angular": "~2.16.x",
-    "ovh-ui-kit": "~2.16.x",
+    "ovh-ui-angular": "~2.17.x",
+    "ovh-ui-kit": "~2.17.x",
     "ovh-api-services": "^3.0.0"
   },
   "private": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ovh-manager-web",
-  "version": "13.4.15",
+  "version": "13.4.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Bump `ovh-ui-kit` and `ovh-ui-kit-bs`

### Description of the Change

8764ffb — chore(deps): bump ovh-ui-kit and ovh-ui-kit-bs

bump:
- ovh-ui-angular from `v2.16.x` to `v2.17.x`
- ovh-ui-kit from `v2.16.x` to `v2.17.x`
- ovh-ui-kit-bs from `v1.2.x` to `v1.3.x`

/cc @jleveugle @Jisay @frenautvh @cbourgois 