### PR TITLE
fix(ftp link): change ftp server link

### DIFF
--- a/client/app/hosting/ftp/FTP.html
+++ b/client/app/hosting/ftp/FTP.html
@@ -160,6 +160,11 @@
                     <dl>
                         <dt data-i18n-static="hosting_tab_FTP_dashboard_server"></dt>
                         <dd class="mb-3">
+                            <oui-clipboard class="w-75" data-model="ftp.url"></oui-clipboard>
+                        </dd>
+
+                        <dt data-i18n-static="hosting_tab_FTP_dashboard_server_link"></dt>
+                        <dd class="mb-3">
                             <a data-ng-href="ftp://{{ftp.url}}:{{ftp.port}}/" target="_blank" title="{{i18n.hosting_dashboard_service_home_ftp_newtab}}">
                                 <span data-ng-bind="ftpUrl"></span>
                                 <span class="fa fa-external-link" aria-hidden="true"></span>

--- a/client/app/resources/i18n/hosting/Messages_fr_FR.xml
+++ b/client/app/resources/i18n/hosting/Messages_fr_FR.xml
@@ -798,6 +798,7 @@
    <translation id="hosting_tab_FTP_dashboard_title" qtlid="198571">Informations FTP</translation>
    <translation id="hosting_tab_FTP_dashboard_information" qtlid="198584">Ces paramètres vous permettront de mettre votre site en ligne</translation>
    <translation id="hosting_tab_FTP_dashboard_server" qtlid="198597">Serveur FTP :</translation>
+   <translation id="hosting_tab_FTP_dashboard_server_link">Lien FTP vers le cluster :</translation>
    <translation id="hosting_tab_FTP_dashboard_login" qtlid="198610">Login principal :</translation>
    <translation id="hosting_tab_FTP_dashboard_primary_ftp_login" qtlid="488848">Login FTP principal :</translation>
    <translation id="hosting_tab_FTP_dashboard_primary_ssh_login" qtlid="488861">Login SSH principal :</translation>


### PR DESCRIPTION
### Requirements
Fix the way ftp server link is represented

## Fix for FTP server information


### Description of the Change

change the way ftp info is shown
add ftp server and ftp cluster link separately

### Benefits

Helps client to properly copy ftp server address

### Possible Drawbacks

None

### Applicable Issues
MFRWW-524
