### PR TITLE
fix(cloudweb): display default runtime in general infos

### DIFF
--- a/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
+++ b/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
@@ -7,6 +7,7 @@ angular.module('App').controller(
       Alerter,
       hostingSSLCertificate,
       translator,
+      HostingRuntimes,
     ) {
       this.$scope = $scope;
       this.$stateParams = $stateParams;
@@ -14,10 +15,24 @@ angular.module('App').controller(
       this.Alerter = Alerter;
       this.hostingSSLCertificate = hostingSSLCertificate;
       this.translator = translator;
+      this.HostingRuntimes = HostingRuntimes;
     }
 
     $onInit() {
       this.$scope.$on('hosting.ssl.reload', () => this.retrievingSSLCertificate());
+
+      this.loading = {
+        defaultRuntime: true,
+      };
+
+      this.defaultRuntime = null;
+      this.HostingRuntimes.getDefault(this.$stateParams.productId)
+        .then((runtime) => {
+          this.defaultRuntime = runtime;
+        })
+        .finally(() => {
+          this.loading.defaultRuntime = false;
+        });
 
       return this.retrievingSSLCertificate();
     }

--- a/client/app/hosting/runtimes/hosting-runtimes.service.js
+++ b/client/app/hosting/runtimes/hosting-runtimes.service.js
@@ -55,6 +55,16 @@ angular.module('services').service(
     }
 
     /**
+     * Get default runtime
+     * @param serviceName
+     */
+    getDefault(serviceName) {
+      return this.list(serviceName)
+        .then(runtimeIds => this.$q.all(_(runtimeIds).map(runtimeId => this.get(serviceName, runtimeId)).value()))
+        .then(runtimes => _(runtimes).filter(runtime => runtime.isDefault).first());
+    }
+
+    /**
      * Get runtime attached domains
      * @param serviceName
      * @param id


### PR DESCRIPTION
Displaying the default runtime of a cloudweb was broken by a merge conflict.
I added the code back (this was already PR reviewed).
MFRWW-949