### PR TITLE
fix(create-auto-response): start date fix

### DIFF
--- a/client/app/email-domain/email/responder/create/email-domain-email-responder-create.html
+++ b/client/app/email-domain/email/responder/create/email-domain-email-responder-create.html
@@ -135,7 +135,8 @@
                                  data-locale="{{translator.locale}}"
                                  data-start-view="month">
                                 <input type="text" class="form-control" id="date-responder-start" name="responderDateStart" required
-                                       data-ng-model="ctrl.model.responderDateStart">
+                                       data-ng-model="ctrl.model.responderDateStart"
+                                       data-ng-model-options="{ updateOn: 'blur' }">
                                 <div class="input-group-addon">
                                     <span class="fa fa-calendar" aria-hidden="true"></span>
                                 </div>


### PR DESCRIPTION
MFRWW-815

### Requirements

In the create auto-response screen, the user is not able to type into the Start date field. This has to be fixed.

## Create auto-response start date fix

### Description of the Change

The start date field currently does not have the updateOn: 'blur' option set (but this is being used in the end date). This triggers an update for each key-stroke and results in the date being reset to the default value. The updateOn: 'blur' option has now been added, so that the user can type into the date field.