### PR TITLE
fix(hosting): call ovhConfigRefresh when last call was at least 12h ago

### DIFF
--- a/client/app/hosting/hosting.controller.js
+++ b/client/app/hosting/hosting.controller.js
@@ -86,6 +86,7 @@ angular
             taskPending: _.get($scope.ovhConfig, 'taskPending', false),
             taskPendingError: _.get($scope.ovhConfig, 'taskPendingError', false),
           });
+
           $scope.phpVersionSupport = _.find(
             $scope.hosting.phpVersions,
             (version) => {
@@ -335,8 +336,15 @@ angular
                     }
                   }
                 })
+                .then(() => {
+                  if (moment().isAfter(moment($scope.hostingProxy.lastOvhConfigScan).add(12, 'hours'))) {
+                    return HostingOvhConfig.ovhConfigRefresh($stateParams.productId);
+                  }
+                  return null;
+                })
                 .finally(() => {
                   $scope.loadingHostingInformations = false;
+                  loadOvhConfig();
                 });
 
               User.getUrlOfEndsWithSubsidiary('hosting').then((url) => {
@@ -365,11 +373,6 @@ angular
                   $scope.loadingHostingError = true;
                 }
               }
-
-              // error 409 and 403 have no matter, they juste saying: "the job is pending"
-              // and other ?  I think is a kind of sub treat as "best effort"
-              // Anyway, the ovhConfig must be loaded
-              HostingOvhConfig.ovhConfigRefresh($stateParams.productId).finally(loadOvhConfig);
 
               if (!hosting.isExpired) {
                 checkFlushCdnState();


### PR DESCRIPTION
We want to refresh OVH config only when the last call was more than 12 hours ago.

ref: MFRWW-868