### PR TITLE
fix(domain.general.informations): remove alert message from domain without hosting

### DIFF
--- a/client/app/domain/general-informations/domain-general-informations.controller.js
+++ b/client/app/domain/general-informations/domain-general-informations.controller.js
@@ -205,7 +205,7 @@ angular.module('App').controller(
     getAssociatedHosting(serviceName) {
       this.loading.associatedHosting = true;
       this.hostingAssociated = [];
-      return this.HostingDomain.getAttachedDomains(serviceName)
+      return this.HostingDomain.getHostingWithAttachedDomain(serviceName)
         .then((response) => {
           if (_.isArray(response) && !_.isEmpty(response)) {
             this.hasHostingAssociate = true;

--- a/client/app/hosting/multisite/hosting-multisite.service.js
+++ b/client/app/hosting/multisite/hosting-multisite.service.js
@@ -403,6 +403,20 @@ angular.module('services').service(
     }
 
     /**
+     * Return array of hosting with domain attached
+     * @param {string} serviceName
+     * @return Array
+     */
+    getHostingWithAttachedDomain(serviceName) {
+      return this.OvhHttp.get('/hosting/web/attachedDomain', {
+        rootPath: 'apiv6',
+        params: {
+          domain: serviceName,
+        },
+      });
+    }
+
+    /**
      * Get attached domains
      * @param {string} serviceName
      * @param {string} attachedDomain


### PR DESCRIPTION
Hello

### Requirements : 

When you select a domain name in general informations. If the domain name hasn't web hosting associated, you have alert message : 

> There was an error when retrieving associated web hosting plans (This service does not exist)

The domain name hasn't web hosting so, it isn't necessary to show alert message but we can show all web hostings with the associated domain


## fix(domain.general.informations): remove alert message from domain without hosting

### Description of the Change:

I create new function getHostingWithAttachedDomain based on api:/hosting/web/attachedDomain instead of getAttachedDomains because function getAttachedDomains return 404 if the service doesn't exist. 

I use new function getHostingWithAttachedDomain in domain-general-informations.controller.js

### Benefits

Help clients 