### PR TITLE
fix: cron job edit

### DIFF
--- a/client/app/hosting/cron/hosting-cron.service.js
+++ b/client/app/hosting/cron/hosting-cron.service.js
@@ -95,7 +95,7 @@ angular.module('services').service('HostingCron', function hostingCron($q, OvhHt
       serviceName,
     },
     data: {
-      command: model.command,
+      command: model.command.startsWith('./') ? model.command.slice(2) : model.command,
       description: model.description || undefined,
       email: model.email || undefined,
       frequency: model.frequency,


### PR DESCRIPTION
MANAGER-630

### Requirements

While editing a cron job in hosting, it automatically adds a "./" to the beginning of the command. This happens only at edit time and is working fine at the creation time. This has to be fixed

## Cron Job Edit fix

### Description of the Change

This issue has been fixed by removing the "./" portion of the command, before calling the edit cron API.