### PR TITLE
fix(deps): bump ovh-module-exchange to v8.0.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5625,8 +5625,8 @@ ovh-module-emailpro@ovh-ux/ovh-module-emailpro#^5.1.0:
   resolved "https://codeload.github.com/ovh-ux/ovh-module-emailpro/tar.gz/cc0aee792cd150a0ad4ab4453a87dda5efbd0720"
 
 ovh-module-exchange@ovh-ux/ovh-module-exchange#^8.0.0:
-  version "8.0.7"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/2a1f3207875a88d7cb3ff92b6ca8216a9b691d6a"
+  version "8.0.8"
+  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/645f3132cc6ca4de9e0a0dae16d8ae9cf930c58d"
 
 ovh-module-office@ovh-ux/ovh-module-office#^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
## Bump `ovh-module-exchange` to `v8.0.8`

### Description of the Change

f4291a4 — fix(deps): bump ovh-module-exchange to v8.0.8

ref: MANAGER-586

/cc @varun257 