### PR TITLE
fix(domain.operation.update): text not interpreted unnecessary

### DIFF
--- a/client/app/domain-operation/update/domain-operation-update.html
+++ b/client/app/domain-operation/update/domain-operation-update.html
@@ -45,7 +45,6 @@
                                 </div>
 
                                 <div class="mt-1 text-center" data-ng-switch-when="/me/contact">
-                                    <span data-translate="domains_operations_update_nicowner"></span>
                                     <a target="_blank" title="{{::('domains_operations_update_nicowner_click_' + arg.key | translate) + ' (' + ('core_new_window' | translate) + ')'}}"
                                        data-ng-href="{{'#/useraccount/contact/' + arg.value + '/' + (arg.fields.length ? ctrl.constructor.getNicParams(arg) : '')}}">
                                         <span data-ng-bind="'domains_operations_update_nicowner_click_' + arg.key | translate"></span>


### PR DESCRIPTION
## fix(domain.operation.update): text not interpreted unnecessary

### Description of the Change

Kill useless text, uninterpreted and duplicate of what is already present
