### PR TITLE
fix(private.database.state): dont display menu when expired

### DIFF
--- a/client/app/private-database/state/private-database-state.html
+++ b/client/app/private-database/state/private-database-state.html
@@ -298,12 +298,12 @@
                                                             data-ng-bind="'privateDatabase_password_' + stateCtrl.database.infrastructure | translate"></strong>
                                                     <span data-ng-show="!taskState.changeFtpPassword">********</span>
                                                 </div>
-                                                <div class="ml-auto my-auto">
+                                                <div class="ml-auto my-auto"
+                                                     data-ng-if="!stateCtrl.isExpired">
                                                     <oui-action-menu data-compact data-align="end"
                                                                      data-ng-if="!taskState.changeFtpPassword">
                                                         <oui-action-menu-item data-on-click="stateCtrl.changeFtpPassword()"
-                                                                              data-ng-disabled="taskState.lockAction"
-                                                                              data-ng-if="!stateCtrl.isExpired">
+                                                                              data-ng-disabled="taskState.lockAction">
                                                             <span data-translate="privateDatabase_change_rootPassword"></span>
                                                         </oui-action-menu-item>
                                                     </oui-action-menu>


### PR DESCRIPTION
## fix(private.database.state): dont display menu when expired


### Description of the Change
Bug in production, if the service is expired we display a oui-action-menu with empty item. 
Goal is to don't display oui-action-menu when service is expired.
