### PR TITLE
Upgrade Emailpro and Exchange modules

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -767,9 +767,9 @@
     ret "^0.2.0"
 
 "@ckeditor/ckeditor5-build-classic@^11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-11.0.1.tgz#e73203424ca59f254e9ba1f6224d2d6f8793c4b7"
-  integrity sha512-iVP2yEFM/ALwKVOynkjGZqPxdK4ecKGI+1oZXYdPPzkd58/4x6gSMKvh54znhNYbNsO7UsLj7+HllP/+5u50uw==
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-11.1.1.tgz#2eb3706bc83640bdc5f6d50e3a060aa70cf495aa"
+  integrity sha512-YfXokhH3Z82zdu4KCfYj2/7I0KyQav5QhNBDKnliXVGgNDuFa529xWr6x+tMx57vu+iiiih7Nmxd86A7tvsh/w==
 
 "@commitlint/cli@^7.1.2":
   version "7.2.0"
@@ -7561,8 +7561,8 @@ ovh-manager-webfont@ovh-ux/ovh-manager-webfont#^1.0.1:
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/1d759c46c8c3ead4bc5e887a2336abd124a17c58"
 
 ovh-module-emailpro@ovh-ux/ovh-module-emailpro#^7.0.1:
-  version "7.0.1"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-emailpro/tar.gz/786b1fd8022517398529f1d33147bc73c8af03a4"
+  version "7.0.3"
+  resolved "https://codeload.github.com/ovh-ux/ovh-module-emailpro/tar.gz/ab1f22d8e046904635c974fef89be8f9e25c11a9"
   dependencies:
     "@ckeditor/ckeditor5-build-classic" "^11.0.1"
     angular "~1.6.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7571,8 +7571,8 @@ ovh-module-emailpro@ovh-ux/ovh-module-emailpro#^7.0.1:
     punycode "^1.2.4"
 
 ovh-module-exchange@ovh-ux/ovh-module-exchange#^9.0.1:
-  version "9.0.1"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/49bd866609e6e3e33bf163a7384897eb01c520b3"
+  version "9.0.3"
+  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/c62aa11f08948229b26b3cd3ce5970746701ed89"
   dependencies:
     "@ckeditor/ckeditor5-build-classic" "^11.0.1"
     lodash "~3.9.3"


### PR DESCRIPTION
## Upgrade Emailpro and Exchange modules

### Description of the Change

6e50345 — build(deps): upgrade ovh-module-emailpro to v7.0.3
7346a87 — build(deps): upgrade ovh-module-exchange to v9.0.3

/cc @jleveugle @frenautvh @cbourgois 