### PR TITLE
Bump manager webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once you have enabled the development mode just ran:
 yarn start
 ```
 
-And now open `https://localhost:9000`.
+And now open `http://localhost:9000`.
 
 ## Test
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,9 +963,9 @@
   integrity sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
 
 "@ovh-ux/manager-webpack-config@^2.3.1":
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-config/-/manager-webpack-config-2.3.4.tgz#970e8812f6b3bc9a9614dc4a4e8f177a0d2cc8d7"
-  integrity sha512-3YPHujcSDrU/ThH3dBdTSMzw+uBn4dlxvDun3LBFR+TTpZHchoeBrqzkQrnqZZ1tFh02aj58bPxBLcHzPh5Emg==
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-config/-/manager-webpack-config-2.3.6.tgz#61cdbaa6b6ee3536f9781e5a92131532967254aa"
+  integrity sha512-7pyPEdHt05trq+E0eUbQnPsX6YvDBOrex3JbR3GzBY5xvnOM4dXBSqipkY2Ql+Cs2EpmEyf89MjTMCW1b3zBqQ==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.0.0"
@@ -1002,16 +1002,15 @@
     webpackbar "^2.6.3"
 
 "@ovh-ux/manager-webpack-dev-server@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-dev-server/-/manager-webpack-dev-server-2.0.0.tgz#97f4ec161e483d0f1ac76cb5f7b94716bc178ff7"
-  integrity sha512-Ut9AWmUDY3Jh8YiDZi3IHMPHAKHO24ugL9b6kRK4GP52iguoaBwSxaKxwwBZXNihAF75ambK3M/0oZWDsrLLaw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-webpack-dev-server/-/manager-webpack-dev-server-2.0.2.tgz#dab3ea523c6dbd1f02230b9697afaa3d6774d698"
+  integrity sha512-8Q/QIu5SiQ0Ae2DCHDGwS+K1EzbZfHcwTySJGF5vJTLDuCugpfm4anHauZ3AG88+PG4J/UHoHIc/aHWZpQ6ZGA==
   dependencies:
     base64url "^3.0.0"
     cookie "^0.3.1"
     duplicate-package-checker-webpack-plugin "^3.0.0"
     friendly-errors-webpack-plugin "^1.7.0"
     request "^2.88.0"
-    time-fix-plugin "^2.0.3"
     webpack-dev-server "^3.1.9"
 
 "@ovh-ux/ovh-utils-angular@^13.0.0":
@@ -5059,10 +5058,10 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-he@1.1.x:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
+he@1.2.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -5107,14 +5106,14 @@ html-entities@^1.2.0:
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
 html-minifier@^3.2.3:
-  version "3.5.20"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.20.tgz#7b19fd3caa0cb79f7cde5ee5c3abdf8ecaa6bb14"
-  integrity sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==
+  version "3.5.21"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"
+  integrity sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==
   dependencies:
     camel-case "3.0.x"
     clean-css "4.2.x"
     commander "2.17.x"
-    he "1.1.x"
+    he "1.2.x"
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.4.x"
@@ -6873,9 +6872,9 @@ minimist@~0.0.1:
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.2.1, minipass@^2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.4.tgz#4768d7605ed6194d6d576169b9e12ef71e9d9957"
-  integrity sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
@@ -9864,11 +9863,6 @@ thunky@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826"
   integrity sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==
-
-time-fix-plugin@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/time-fix-plugin/-/time-fix-plugin-2.0.4.tgz#2436f837279e105902c985cd4c29eacbe9c51c0a"
-  integrity sha512-AXKqo4NI2ZrRAnO+9OYn8LwV3rwLiJHlEn9S1Ov86+i0RI4p6nR/uVjNasozJMTLs7fq/TWgPSsa7nI/kbV4UQ==
 
 timers-browserify@^2.0.4:
   version "2.0.10"


### PR DESCRIPTION
## Bump manager webpack config

⚠️ do not merge ⚠️ 

### Description of the Change

066b7a2 — build(deps): bump manager-webpack-config to v2.3.6
6826886 — docs(readme): update default protocol to http

/cc @jleveugle @frenautvh @cbourgois 