### PR TITLE
fix(*): multisite-modification returns error

### DIFF
--- a/client/app/hosting/multisite/hosting-multisite.controller.js
+++ b/client/app/hosting/multisite/hosting-multisite.controller.js
@@ -205,7 +205,7 @@ angular
       });
 
       $scope.$on('hostingDomain.modifyDomain.done', () => {
-        $scope.$broadcast('paginationServerSide.reload');
+        reloadCurrentPage();
         Alerter.success(
           $translate.instant('hosting_tab_DOMAINS_configuration_modify_success_finish'),
           $scope.alerts.main,
@@ -213,7 +213,7 @@ angular
       });
 
       $scope.$on('hostingDomain.modifyDomain.error', (err) => {
-        $scope.$broadcast('paginationServerSide.reload');
+        reloadCurrentPage();
         Alerter.alertFromSWS(
           $translate.instant('hosting_tab_DOMAINS_configuration_modify_failure'),
           _.get(err, 'data', err),

--- a/client/app/hosting/multisite/update/hosting-multisite-update.controller.js
+++ b/client/app/hosting/multisite/update/hosting-multisite-update.controller.js
@@ -296,11 +296,20 @@ angular
           })
           .catch((err) => {
             _.set(err, 'type', err.type || 'ERROR');
-            Alerter.alertFromSWS(
-              $translate.instant('hosting_tab_DOMAINS_configuration_modify_failure'),
-              _.get(err, 'data', err),
-              $scope.alerts.main,
-            );
+            if (_.isEqual(err.status, 403) && _.includes(err.data, 'updating')) {
+              // show update in progress error
+              Alerter.alertFromSWS(
+                $translate.instant('hosting_tab_DOMAINS_configuration_modify_failure_inprogress'),
+                _.get(err, 'data', err),
+                $scope.alerts.main,
+              );
+            } else {
+              Alerter.alertFromSWS(
+                $translate.instant('hosting_tab_DOMAINS_configuration_modify_failure'),
+                _.get(err, 'data', err),
+                $scope.alerts.main,
+              );
+            }
           });
       };
     },

--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -523,6 +523,7 @@
    <translation id="hosting_tab_DOMAINS_configuration_remove_success_finish" qtlid="232453">Le domaine a été détaché de votre hébergement mutualisé avec succès.</translation>
    <translation id="hosting_tab_DOMAINS_configuration_remove_partial" qtlid="197518">Certains domaines vont être détachés de votre hébergement mutualisé, mais des erreurs sont survenues pour d'autres.</translation>
    <translation id="hosting_tab_DOMAINS_configuration_remove_failure" qtlid="197531">Une erreur est survenue lors du détachement du domaine de votre hébergement mutualisé.</translation>
+   <translation id="hosting_tab_DOMAINS_configuration_modify_failure_inprogress">La mise à jour de votre ou vos domaines a échoué car une autre opération est en cours. Veuillez réessayer ultérieurement.</translation>
 
    <translation id="hosting_tab_DOMAINS_configuration_modify_title" qtlid="211476">Modifier un domaine</translation>
    <translation id="hosting_tab_DOMAINS_configuration_modify_step1_question" qtlid="197544">Vous allez modifier le domaine suivant :</translation>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
Hosting: multisite: modifying a domain fails sometimes

### Description of the Change
Domain modification fails if there is already request modification is in progress. In this case, UI does not show a proper message to a user. Because of this, a user does not know why it failed.

I have added a proper error message and also modified the code to avoid full page refresh.

### Benefits

fixes issue MBE-13

### Possible Drawbacks
none

### Applicable Issues

MBE-13