### PR TITLE
fix(deps): upgrade ovh-module-emailpro to v7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ovh-api-services": "ovh-ux/ovh-api-services#^3.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-module-emailpro": "ovh-ux/ovh-module-emailpro#^7.0.1",
+    "ovh-module-emailpro": "^7.0.6",
     "ovh-module-exchange": "ovh-ux/ovh-module-exchange#^9.0.1",
     "ovh-module-office": "ovh-ux/ovh-module-office#^7.0.0",
     "ovh-module-sharepoint": "ovh-ux/ovh-module-sharepoint#^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8470,9 +8470,10 @@ ovh-manager-webfont@ovh-ux/ovh-manager-webfont#^1.0.1:
   version "1.0.2"
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/1d759c46c8c3ead4bc5e887a2336abd124a17c58"
 
-ovh-module-emailpro@ovh-ux/ovh-module-emailpro#^7.0.1:
-  version "7.0.5"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-emailpro/tar.gz/7cbff19496e9b1164a1623e4e51a712799eca323"
+ovh-module-emailpro@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.0.6.tgz#cd4d412f56b0f573597c460bcf66c3821c06dbfe"
+  integrity sha512-PS3kzvVsGPhUOOS/HHTl+urrd5RlgGvkd3q6d8FH03ZeMoHbllvBflZYuKtvTy61m5UzQrtAqBouUw17DtKqBg==
   dependencies:
     angular "~1.6.10"
     lodash "~3.9.3"


### PR DESCRIPTION
## ⬆️ upgrade `ovh-module-emailpro` to `v7.0.6`

### Description of the Change

ab95748 — fix(deps): upgrade ovh-module-emailpro to v7.0.6

/cc @jleveugle @frenautvh @cbourgois 