### PR TITLE
fix(deps): upgrade ovh-module-exchange to v9.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.0.6",
-    "ovh-module-exchange": "ovh-ux/ovh-module-exchange#^9.0.1",
+    "ovh-module-exchange": "^9.0.5",
     "ovh-module-office": "ovh-ux/ovh-module-office#^7.0.0",
     "ovh-module-sharepoint": "ovh-ux/ovh-module-sharepoint#^7.0.0",
     "ovh-ui-angular": "^2.22.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8480,9 +8480,10 @@ ovh-module-emailpro@^7.0.6:
     moment "^2.16.0"
     punycode "^1.2.4"
 
-ovh-module-exchange@ovh-ux/ovh-module-exchange#^9.0.1:
-  version "9.0.4"
-  resolved "https://codeload.github.com/ovh-ux/ovh-module-exchange/tar.gz/ebf6a39d9be82711b9f83bd7ab70eccca04d87b6"
+ovh-module-exchange@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.0.5.tgz#e6d1d2ce2ae4c39c481c5320726c583b287f2355"
+  integrity sha512-BM4h2GLxWC81O9PB9WN2rCw/y6zkL4p0vzo2DenORGOe0pMhso/N7fu2pFWMaMJnOVxDGWZyEOcxmp/BnEa8iA==
   dependencies:
     lodash "~3.9.3"
 


### PR DESCRIPTION
## ⬆️ upgrade `ovh-module-exchange` to `v9.0.5`

### Description of the Change

edb4719 — fix(deps): upgrade ovh-module-exchange to v9.0.5

/cc @jleveugle @frenautvh @cbourgois 