### PR TITLE
fix(exchange): upgrade ovh-module-exchange to v9.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.0.6",
-    "ovh-module-exchange": "^9.0.6",
+    "ovh-module-exchange": "^9.0.7",
     "ovh-module-office": "ovh-ux/ovh-module-office#^7.0.0",
     "ovh-module-sharepoint": "ovh-ux/ovh-module-sharepoint#^7.0.0",
     "ovh-ui-angular": "^2.22.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8481,10 +8481,10 @@ ovh-module-emailpro@^7.0.6:
     moment "^2.16.0"
     punycode "^1.2.4"
 
-ovh-module-exchange@^9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.0.6.tgz#709e988d7d6bf3780968c1fd4fc69129d74df421"
-  integrity sha512-iJ3yeQYr4xV6zFHBx7Y31zhPiHJtooKBO/yuzIOcw55s3f8zNBRj08GZs+FVOOW4Wgs8a+KXusmZA4Rk1Wy/Aw==
+ovh-module-exchange@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.0.7.tgz#8dc1694c30262d9657acd550a6dbba2b733e4749"
+  integrity sha512-fJhoZZGIFeHusCdpdAKQ2KweeGzXhrPlvp5uAnBG6ZQ+z8xzKKYPSWoB/su95aT8phHOWjXg9tbkRQIsuanAXw==
   dependencies:
     lodash "~3.9.3"
 


### PR DESCRIPTION
## ⬆️ Upgrade `ovh-module-exchange` to `v9.0.7`

### Description of the Change

6f612d3 — fix(exchange): upgrade ovh-module-exchange to v9.0.7

/cc @jleveugle @frenautvh @cbourgois 