### PR TITLE
fix(hosting): expired service error msg

### DIFF
--- a/client/app/hosting/hosting.controller.js
+++ b/client/app/hosting/hosting.controller.js
@@ -360,7 +360,7 @@ angular
                 })
                 .catch(err => Alerter.error(err));
 
-              if (hosting.messages.length > 0) {
+              if (!hosting.isExpired && hosting.messages.length > 0) {
                 Alerter.error(
                   $translate.instant('hosting_dashboard_loading_error'),
                   $scope.alerts.page,


### PR DESCRIPTION
Close MBE-11

### Requirements

When a hosting service has expired, we get an irrelevant error message "An error has occurred loading information. This sometimes happens when there is an ad-blocker enabled." when we open the service. This error message should not be displayed.

## Error Message Handling for expired hosting services


### Description of the Change

When a hosting service has expired, we now only show the relevant warning message and the error message is not shown.