### PR TITLE
fix(add-status): add status message to ftp backup

### DIFF
--- a/client/app/email-domain/email/responder/email-domain-email-responder.html
+++ b/client/app/email-domain/email/responder/email-domain-email-responder.html
@@ -32,7 +32,7 @@
             <oui-datagrid data-rows="$ctrl.responders" data-row-loader="$ctrl.transformItem($row)">
                 <oui-column data-title=":: 'email_tab_responders_name' | translate" data-property="account"></oui-column>
                 <oui-column data-title=":: 'emails_common_date_from' | translate" data-property="from">
-                    <span data-ng-bind="::'$row.from | date: 'medium'" data-ng-if="$row.from"></span>
+                    <span data-ng-bind="::$row.from | date: 'medium'" data-ng-if="$row.from"></span>
                 </oui-column>
                 <oui-column data-title=":: 'emails_common_date_to' | translate" data-property="to">
                     <span data-ng-bind="::$row.to | date: 'medium'" data-ng-if="$row.to"></span>

--- a/client/app/hosting/task/TASK.html
+++ b/client/app/hosting/task/TASK.html
@@ -18,6 +18,7 @@
                   ):
                   ('hosting_tab_TASKS_function_'+ $row.function | translate)">
             </span>
+            <div data-ng-if="$row.function.indexOf('restoreSnapshot') !== -1" class="oui-tile__term" data-translate="hosting_tab_TASKS_status_backup_FTP"></div>
         </oui-column>
         <oui-column data-title="'hosting_tab_TASKS_table_start_date' | translate" data-property="status">
             <span class="oui-status"

--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -745,6 +745,7 @@
    <translation id="hosting_tab_TASKS_status_TODO" qtlid="197947">Planifiée</translation>
    <translation id="hosting_tab_TASKS_status_INIT" qtlid="197960">Initiée</translation>
 
+   <translation id="hosting_tab_TASKS_status_backup_FTP">La sauvegarde générée vous sera envoyée par courrier électronique et ne sera pas automatiquement restaurée sur votre espace FTP.</translation>
    <translation id="hosting_tab_TASKS_function_hosting_install" qtlid="197973">Installation de l'hébergement</translation>
    <translation id="hosting_tab_TASKS_function_hosting_install_paas" qtlid="197986">Installation de l'hébergement en mode PAAS</translation>
 <translation id="hosting_tab_TASKS_function_hosting_changement"/>

--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -761,7 +761,7 @@
    <translation id="hosting_tab_TASKS_function_web_changeLock" qtlid="198090">Bloquage du compte FTP</translation>
 <translation id="hosting_tab_TASKS_function_web_rightClose"/>
 <translation id="hosting_tab_TASKS_function_web_changeShell"/>
-   <translation id="hosting_tab_TASKS_function_web_restoreSnapshot" qtlid="26899">Restauration d'un snapshot</translation>
+   <translation id="hosting_tab_TASKS_function_web_restoreSnapshot">Création d'un snapshot</translation>
 <translation id="hosting_tab_TASKS_function_web_delete"/>
    <translation id="hosting_tab_TASKS_function_web_addUser" qtlid="198103">Ajout d'un utilisateur FTP</translation>
    <translation id="hosting_tab_TASKS_function_web_changeUser" qtlid="198116">Modification d'un utilisateur FTP</translation>


### PR DESCRIPTION
## Add details to status message and fix from date missing in email auto response list


### Description of the Change

add subtext to ftp message for backup
remove typo to fix from date message

### Benefits
Helps understand the status better

### Possible Drawbacks

None

### Applicable Issues

resolves MBE-78 and MBE-113
