### PR TITLE
fix(icons): use different icon for domains and DNS

### DIFF
--- a/client/app/components/sidebar-menu/sidebar-menu.config.js
+++ b/client/app/components/sidebar-menu/sidebar-menu.config.js
@@ -118,7 +118,7 @@ angular.module('App').run(($q, $translate, SidebarMenu, Products, User, atIntern
         const allDomItem = SidebarMenu.addMenuItem({
           title: domain.displayName,
           category: 'domain',
-          icon: 'ovh-font ovh-font-domain',
+          icon: 'oui-icon oui-icon-domain-dns icon-white-background',
           allowSubItems: true,
           loadOnState: 'app.domain.alldom',
           loadOnStateParams: {

--- a/client/app/css/less/common/icon.less
+++ b/client/app/css/less/common/icon.less
@@ -9,6 +9,10 @@
   background-image: url("../../../../assets/images/glyphicons-halflings-white.png");
 }
 
+.icon-white-background {
+  color: @white;
+}
+
 .icon-warning {
   width: 16px;
   height: 16px;

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "ovh-module-office": "ovh-ux/ovh-module-office#^7.0.0",
     "ovh-module-sharepoint": "ovh-ux/ovh-module-sharepoint#^7.0.0",
     "ovh-ui-angular": "^2.22.x",
-    "ovh-ui-kit": "^2.22.x",
+    "ovh-ui-kit": "^2.22.1",
     "ovh-ui-kit-bs": "~1.3.x",
     "properties": "latest",
     "punycode": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8438,10 +8438,10 @@ ovh-ui-kit@^2.20.0:
   dependencies:
     less-plugin-remcalc "^0.1.0"
 
-ovh-ui-kit@^2.22.x:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.22.0.tgz#9a084e938bc7404f40d8e3cc6f218eb59733c592"
-  integrity sha512-/ZYob5gjzC7lv//N/MpHO84KBZWD5eR4c0/fDBOKNxs1fkf7ockzp+u9dCVIMHBKezwGN0wcxVqwx/SmRJuebg==
+ovh-ui-kit@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/ovh-ui-kit/-/ovh-ui-kit-2.22.1.tgz#ee439bf2a281239336a5cd7b872d0a753335e19f"
+  integrity sha512-XwWqBtkXcVT7YxtA8OxNlld8r7cqGSIiypAqg6zj6oQvlmlOczNEPGj8KMAivHZELMRs/wZV13Iw0kj+iOZ6zw==
   dependencies:
     less-plugin-remcalc "^0.1.0"
 


### PR DESCRIPTION
use different icon for domain and DNS in navigation menu for manager web

Closes #MBE-18

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
Use a different icon for domain and DNS

### Description of the Change
Used different icon for domain and DNS in the navigation menu for the manager web

### Benefits


### Possible Drawbacks
None

### Applicable Issues
 #MBE-18

