### PR TITLE
fix(translation): email status is not translated

### DIFF
--- a/client/app/email/translations/Messages_fr_FR.xml
+++ b/client/app/email/translations/Messages_fr_FR.xml
@@ -266,6 +266,7 @@
    <translation id="email_tab_alias_quota" qtlid="224841">Quota des alias</translation>
    <translation id="email_tab_domain_status" qtlid="19843">Etat du service</translation>
    <translation id="email_tab_domain_status_ok" qtlid="55133">Actif</translation>
+   <translation id="email_tab_domain_status_close">Expiré</translation>
    <translation id="email_tab_domain_filer" qtlid="225902">Filer email</translation>
    <translation id="email_tab_domain_offer" qtlid="38217">Offre</translation>
    <translation id="email_tab_unavailable" qtlid="255508">Les emails ne sont pas accessibles</translation>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

## Title of the Pull Requests <!-- required -->
Email service status not translated for expired emails

### Description of the Change
The translation was not found. I have added it.

### Benefits

### Possible Drawbacks
None

### Applicable Issues
MBE-123
