### PR TITLE
fix(hosting.databases): update upgrade text

### DIFF
--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -165,9 +165,9 @@
    <translation id="hosting_dashboard_service_renew" qtlid="118962">Renouveler</translation>
    <translation id="hosting_dashboard_service_change_offer" qtlid="95995">Changer d'offre</translation>
    <translation id="hosting_dashboard_service_change_offer_explanation" qtlid="327237">Basculer sur un hébergement payant afin de créer une base de données. C'est rapide et sans coupures. Nos offres vous permettrons d'obtenir :</translation>
-   <translation id="hosting_dashboard_service_change_offer_explanation_ftp" qtlid="327250">Un FTP d'au moins 100 Go</translation>
-   <translation id="hosting_dashboard_service_change_offer_explanation_mail" qtlid="327263">Un minimum de 10 adresses e-mail de 5 Go</translation>
-   <translation id="hosting_dashboard_service_change_offer_explanation_db" qtlid="327276">Une base de données commençant à 200 Mo</translation>
+   <translation id="hosting_dashboard_service_change_offer_explanation_ftp">Un FTP d'au moins 1 Go</translation>
+   <translation id="hosting_dashboard_service_change_offer_explanation_mail">Un minimum de 2 adresses e-mail de 5 Go</translation>
+   <translation id="hosting_dashboard_service_change_offer_explanation_db">Une base de données commençant à 100 Mo</translation>
    <translation id="hosting_dashboard_service_change_offer_now" qtlid="327289">Changer d'offre maintenant</translation>
    <translation id="hosting_dashboard_service_order_ssl" qtlid="196803">Commander un certificat SSL</translation>
    <translation id="hosting_dashboard_service_order_cdn" qtlid="217626">Commander un CDN</translation>


### PR DESCRIPTION
Close MBE-165

### Requirements

The specs given in hosting>databases upgrade message is wrong

Nos offres vous permettrons d'obtenir :

Un FTP d'au moins 100 Go
Un minimum de 10 adresses e-mail de 5 Go
Une base de données commençant à 200 Mo

This information does not take into account the offer "Web Kimsufi". The exact information should be : 

Nos offres vous permettrons d'obtenir :

Un FTP d'au moins 1 Go
Un minimum de 2 adresses e-mail de 5 Go
Une base de données commençant à 100 Mo

## Database upgrade text update


### Description of the Change

The above text change is done