### PR TITLE
fix(sql_order): db order ram unit

### DIFF
--- a/client/app/private-database/order/sql-database-order-controller.js
+++ b/client/app/private-database/order/sql-database-order-controller.js
@@ -475,5 +475,11 @@ angular.module('App').controller(
     makeHostingUrl(serviceName) {
       return this.hostingUrl + serviceName;
     }
+
+    getNormalizedRAMSize(ramSize) {
+      return ramSize < 1024
+        ? ramSize + this.$translate.instant('unit_size_MB')
+        : ramSize / 1024 + this.$translate.instant('unit_size_GB');
+    }
   },
 );

--- a/client/app/private-database/order/sql-database-order.html
+++ b/client/app/private-database/order/sql-database-order.html
@@ -91,7 +91,7 @@
                             <select class="oui-select__input" id="orderRam" name="orderRam" required
                                     data-ng-change="$ctrl.getDuration()"
                                     data-ng-model="$ctrl.model.ram"
-                                    data-ng-options="ramSize + ('unit_size_MB' | translate) for ramSize in $ctrl.getData($ctrl.model.type).rams track by ramSize">
+                                    data-ng-options="$ctrl.getNormalizedRAMSize(ramSize) for ramSize in $ctrl.getData($ctrl.model.type).rams track by ramSize">
                                 <option value="" disabled
                                         data-translate="select_option"></option>
                             </select>


### PR DESCRIPTION
Close MBE-164

### Requirements

The units for the Ram size in order sql page should match that in the website.

## Database order - RAM size unit fix


### Description of the Change

The RAM size units now match the one in the website.