### PR TITLE
Prepare v13.12.0

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -60,6 +60,7 @@ angular
     urls: config.constants.URLS,
     comodo: config.constants.COMODO,
     CHATBOT_URL: config.constants.CHATBOT_URL,
+    AUTORENEW_URL: config.constants.AUTORENEW_URL,
     BILLING_URL: config.constants.BILLING_URL,
     UNIVERS: config.constants.UNIVERS,
     UNIVERSES: config.constants.UNIVERSES,

--- a/client/app/config/constants.config.js
+++ b/client/app/config/constants.config.js
@@ -6,6 +6,7 @@ module.exports = {
             FACEBOOK_MESSENGER: "https://m.me/975451932604879"
         },
         BILLING_URL: "https://www.ovh.com/manager/dedicated/#/billing/history",
+        AUTORENEW_URL: "https://www.ovh.com/manager/dedicated/#/billing/autoRenew",
         RENEW_URL    : "https://eu.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser={serviceName}",
         LOGS_URCHIN  : "https://logs.ovh.net/{serviceName}/urchin6/",
         LOGS_URCHIN_GRA  : "https://logs.{cluster}.hosting.ovh.net/{serviceName}/urchin6/",
@@ -254,6 +255,7 @@ module.exports = {
                 guides: {
                     home: "https://docs.ovh.com",
                     all: "https://docs.ovh.com/fr/web/",
+                    autoRenew: "https://www.ovh.com/fr/g1271.guide_dutilisation_du_renouvellement_automatique_ovh",
                     hostingCron: "https://www.ovh.com/fr/g1990.mutualise_taches_automatisees_cron",
                     hostingModule: "https://docs.ovh.com/fr/hosting/modules-en-1-clic/",
                     hostingScriptEmail: "https://www.ovh.com/fr/g1974.mutualise_suivi_des_emails_automatises",
@@ -901,6 +903,7 @@ module.exports = {
         }
     },
     CA: {
+        AUTORENEW_URL: "https://ca.ovh.com/manager/dedicated/#/billing/autoRenew",
         RENEW_URL: "https://ca.ovh.com/fr/cgi-bin/order/renew.cgi?domainChooser={serviceName}",
         LOGS_URCHIN: "https://logs.ovh.net/{serviceName}/urchin6/",
         STATS_LOGS: "https://logs.ovh.net/{serviceName}/",

--- a/client/app/configuration/configuration.component.js
+++ b/client/app/configuration/configuration.component.js
@@ -1,0 +1,6 @@
+angular
+  .module('App')
+  .component('configuration', {
+    controller: 'configurationCtrl',
+    templateUrl: 'configuration/configuration.html',
+  });

--- a/client/app/configuration/configuration.controller.js
+++ b/client/app/configuration/configuration.controller.js
@@ -1,51 +1,41 @@
-angular.module('App').controller(
-  'ConfigurationCtrl',
-  class ConfigurationCtrl {
-    constructor(
-      $scope,
-      $route,
-      WucProducts,
-      constants,
-      User,
-    ) {
-      this.$scope = $scope;
-      this.$route = $route;
-      this.WucProducts = WucProducts;
-      this.constants = constants;
-      this.User = User;
-    }
+angular
+  .module('App')
+  .controller(
+    'configurationCtrl',
+    class ConfigurationCtrl {
+      constructor(
+        constants,
+        User,
+      ) {
+        this.constants = constants;
+        this.User = User;
+      }
 
-    $onInit() {
-      this.guides = this.constants.TOP_GUIDES;
+      $onInit() {
+        this.guides = this.constants.TOP_GUIDES;
 
-      this.User.getUser()
-        .then((user) => {
-          this.allGuides = _.get(
-            this.constants,
-            `urls.${user.ovhSubsidiary}.guides.all`,
-            this.constants.urls.FR.guides.all,
-          );
-        })
-        .catch(() => {
-          this.allGuides = this.constants.urls.FR.guides.all;
-        });
+        this.helpCenterURLs = _.omit(
+          _.mapValues(
+            this.constants.urls,
+            'support',
+          ),
+          _.isUndefined,
+        );
 
-      this.currentGuides = [];
-      this.currentTypeOfGuide = null;
+        return this.User
+          .getUser()
+          .then(({ ovhSubsidiary: subsidiary }) => {
+            this.subsidiary = subsidiary;
 
-      this.unSelectProduct();
-      this.selectTypeOfGuide('domainHosting');
-    }
-
-    unSelectProduct() {
-      this.WucProducts.removeSelectedProduct().then((p) => {
-        this.$scope.product = p;
-      });
-    }
-
-    selectTypeOfGuide(typeOfGuide) {
-      this.currentGuides = this.guides[typeOfGuide];
-      this.currentTypeOfGuide = typeOfGuide;
-    }
-  },
-);
+            this.allGuides = _.get(
+              this.constants,
+              `urls.${subsidiary}.guides.all`,
+              this.constants.urls.FR.guides.all,
+            );
+          })
+          .catch(() => {
+            this.allGuides = this.constants.urls.FR.guides.all;
+          });
+      }
+    },
+  );

--- a/client/app/configuration/configuration.html
+++ b/client/app/configuration/configuration.html
@@ -4,13 +4,34 @@
             <span data-translate="welcome_to_your_manager_1"></span>
             <span data-translate="welcome_to_your_manager_2"></span>
         </h1>
-        <p class="lead"
-           data-ng-bind-html="'core_top_guides_header' | translate: { t0: ConfigurationCtrl.allGuides }"></p>
+        <p
+            class="lead"
+            data-ng-if="$ctrl.subsidiary !== 'FR'"
+            data-translate="core_top_guides_header"
+            data-translate-values="{ t0: $ctrl.allGuides }"></p>
+
+        <div
+            class="row"
+            data-ng-if="$ctrl.subsidiary === 'FR'">
+            <p class="lead col-md-offset-1 col-md-10 col-lg-offset-2 col-lg-8">
+                <span data-translate="core_top_guides_header_fr"></span>
+                <a
+                    class="oui-link_icon"
+                    data-ng-href="{{:: $ctrl.helpCenterURLs.FR }}"
+                    target="_blank"
+                    rel="noopener">
+                    <span data-translate="common_menu_support_help_center"></span>
+                    <span class="oui-icon oui-icon-external_link" aria-hidden="true"></span>
+                    <span class="sr-only" data-translate="core_new_window"></span>
+                </a>.
+            </p>
+        </div>
+
     </div>
     <div class="container-fluid">
         <div class="row d-md-flex" data-ng-if="!loaders.loading && user.ovhSubsidiary === 'FR'">
             <div class="col-md-10 col-lg-8 mx-md-auto">
-                <div class="oui-tile pb-5" data-ng-repeat="(key, value) in ConfigurationCtrl.guides track by $index">
+                <div class="oui-tile pb-5" data-ng-repeat="(key, value) in $ctrl.guides track by $index">
                     <h2 class="oui-tile__title" data-ng-bind="'core_type_of_guide_' + key | translate"></h2>
                     <div class="oui-tile__body">
                         <ul class="list-unstyled">
@@ -28,7 +49,7 @@
                             </li>
                             <li class="oui-tile__item">
                                 <div class="oui-tile__definition">
-                                    <a data-ng-href="{{ ConfigurationCtrl.allGuides }}"
+                                    <a data-ng-href="{{ $ctrl.allGuides }}"
                                        target="_blank"
                                        data-track-on="click"
                                        data-track-name="web::TopGuide-Web-10"

--- a/client/app/configuration/configuration.routes.js
+++ b/client/app/configuration/configuration.routes.js
@@ -1,9 +1,7 @@
 angular.module('App').config(($stateProvider) => {
   $stateProvider.state('app.configuration', {
     url: '/configuration',
-    templateUrl: 'configuration/configuration.html',
-    controller: 'ConfigurationCtrl',
-    controllerAs: 'ConfigurationCtrl',
+    component: 'configuration',
     resolve: {
       navigationInformations: [
         'Navigator',

--- a/client/app/core/translations/Messages_cs_CZ.xml
+++ b/client/app/core/translations/Messages_cs_CZ.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Zpět</translation>
    <translation id="common_next" qtlid="17743">Další</translation>
    <translation id="common_previous" qtlid="17431">Předcházející</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">S'ouvre dans un nouvel onglet</translation>
    <translation id="common_activated" qtlid="30250">Aktivní</translation>
    <translation id="common_desactivated" qtlid="24967">Neaktivní</translation>
    <translation id="common_not_supported" qtlid="190771">Není podporován</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Nepodařilo se získat informace o službě {0}.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Restart zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Zobrazit podrobnosti chyb</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Masquer le détail des erreurs</translation>
    <translation id="common_managerv5" qtlid="190784">Manažer V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Váš zákaznický prostor WEB</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Podpora</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Všechny přiručky</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centre d'aide</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Vytvořit ticket</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Seznam mých ticketů</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Demande d'assistance</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Historie e-mailů</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Telefonická podpora</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -564,6 +564,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Změna e-mailu</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Pro více informací se obraťte na <a href="{0}" target="_blank">naše příručky</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domény a webhosting</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Uživatelská příručka k automatickému obnovení služeb společnosti OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Začínáme s webhostingem</translation>

--- a/client/app/core/translations/Messages_de_DE.xml
+++ b/client/app/core/translations/Messages_de_DE.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Zurück</translation>
    <translation id="common_next" qtlid="17743">Weiter</translation>
    <translation id="common_previous" qtlid="17431">Zurück</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Wird in einem neuen Tab geöffnet</translation>
    <translation id="common_activated" qtlid="30250">Aktiviert</translation>
    <translation id="common_desactivated" qtlid="24967">Deaktiviert</translation>
    <translation id="common_not_supported" qtlid="190771">Nicht unterstützt</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Die Informationen zur Dienstleistung {0} konnten nicht gefunden werden.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Den Zoom zurücksetzen</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Die Fehlerdetails anzeigen</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Fehlerdetails verbergen</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager v3</translation>
    <translation id="global_app_title" qtlid="122131">Ihr OVH Web Kundencenter</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Support</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Alle Anleitungen</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help Center</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Eine Support-Anfrage erstellen</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Liste meiner Support-Anfragen</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support-Anfrage</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">E-Mail-History</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Telefonischer Support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Meine E-Mail-Adresse ändern</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Wenn Sie detailliertere Informationen wünschen, lesen Sie bitte <a href="{0}" target="_blank">unsere Anleitungen</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains und Hosting </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Anleitung zur automatischen Verlängerung</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Erste Schritte mit einem Webhosting</translation>

--- a/client/app/core/translations/Messages_en_ASIA.xml
+++ b/client/app/core/translations/Messages_en_ASIA.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Back</translation>
    <translation id="common_next" qtlid="17743">Next</translation>
    <translation id="common_previous" qtlid="17431">Previous</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Open in a new tab</translation>
    <translation id="common_activated" qtlid="30250">Enabled</translation>
    <translation id="common_desactivated" qtlid="24967">Disabled</translation>
    <translation id="common_not_supported" qtlid="190771">Not supported</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Information about the {0} service has not been found.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Reset zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">See the details of the errors</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Hide error details</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager v3</translation>
    <translation id="global_app_title" qtlid="122131">Your OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">All guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help centre</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Create a support request</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">My support requests</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support request</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Email history</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Phone support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Change my e-mail address </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">For more detailed information, please read <a href="{0}" target="_blank">our guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains and hosting packages </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatic renewal user guide </translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Get started with a web hosting package </translation>

--- a/client/app/core/translations/Messages_en_AU.xml
+++ b/client/app/core/translations/Messages_en_AU.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Back</translation>
    <translation id="common_next" qtlid="17743">Next</translation>
    <translation id="common_previous" qtlid="17431">Previous</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Open in a new tab</translation>
    <translation id="common_activated" qtlid="30250">Enabled</translation>
    <translation id="common_desactivated" qtlid="24967">Disabled</translation>
    <translation id="common_not_supported" qtlid="190771">Not supported</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Information about the {0} service has not been found.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Reset zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">See the details of the errors</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Hide error details</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager v3</translation>
    <translation id="global_app_title" qtlid="122131">Your OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">All guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help centre</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Create a support request</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">My support requests</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support request</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Email history</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Phone support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Change my e-mail address </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">For more detailed information, please read <a href="{0}" target="_blank">our guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains and hosting packages </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatic renewal user guide </translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Get started with a web hosting package </translation>

--- a/client/app/core/translations/Messages_en_CA.xml
+++ b/client/app/core/translations/Messages_en_CA.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Back</translation>
    <translation id="common_next" qtlid="17743">Next</translation>
    <translation id="common_previous" qtlid="17431">Previous</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Open in a new tab</translation>
    <translation id="common_activated" qtlid="30250">Enabled</translation>
    <translation id="common_desactivated" qtlid="24967">Disabled</translation>
    <translation id="common_not_supported" qtlid="190771">Not supported</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Information about the {0} service has not been found.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Restart the zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">See the details of the errors</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Hide error details</translation>
    <translation id="common_managerv5" qtlid="190784"></translation>
    <translation id="common_managerv3" qtlid="34512"></translation>
    <translation id="global_app_title" qtlid="122131">Your OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">All guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help centre</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Create a support request</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">My support requests</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support request</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Email history</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Phone support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Change my e-mail address </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">For more detailed information, please read <a href="{0}" target="_blank">our guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains and hosting packages </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatic renewal user guide </translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Get started with a web hosting package </translation>

--- a/client/app/core/translations/Messages_en_GB.xml
+++ b/client/app/core/translations/Messages_en_GB.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Back</translation>
    <translation id="common_next" qtlid="17743">Next</translation>
    <translation id="common_previous" qtlid="17431">Previous</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Open in a new tab</translation>
    <translation id="common_activated" qtlid="30250">Enabled</translation>
    <translation id="common_desactivated" qtlid="24967">Disabled</translation>
    <translation id="common_not_supported" qtlid="190771">Not supported</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Information about the {0} service has not been found.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Reset zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">See the details of the errors</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Hide error details</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager v3</translation>
    <translation id="global_app_title" qtlid="122131">Your OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">All guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help centre</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Create a support request</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">My support requests</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support request</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Email history</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Phone support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Change my e-mail address </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">For more detailed information, please read <a href="{0}" target="_blank">our guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains and hosting packages </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatic renewal user guide </translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Get started with a web hosting package </translation>

--- a/client/app/core/translations/Messages_en_SG.xml
+++ b/client/app/core/translations/Messages_en_SG.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Back</translation>
    <translation id="common_next" qtlid="17743">Next</translation>
    <translation id="common_previous" qtlid="17431">Previous</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Open in a new tab</translation>
    <translation id="common_activated" qtlid="30250">Enabled</translation>
    <translation id="common_desactivated" qtlid="24967">Disabled</translation>
    <translation id="common_not_supported" qtlid="190771">Not supported</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Information about the {0} service has not been found.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Reset zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">See the details of the errors</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Hide error details</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager v3</translation>
    <translation id="global_app_title" qtlid="122131">Your OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">All guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help centre</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Create a support request</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">My support requests</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support request</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Email history</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Phone support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Change my e-mail address </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">For more detailed information, please read <a href="{0}" target="_blank">our guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains and hosting packages </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatic renewal user guide </translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Get started with a web hosting package </translation>

--- a/client/app/core/translations/Messages_en_US.xml
+++ b/client/app/core/translations/Messages_en_US.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Back</translation>
    <translation id="common_next" qtlid="17743">Next</translation>
    <translation id="common_previous" qtlid="17431">Previous</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Open in a new tab</translation>
    <translation id="common_activated" qtlid="30250">Enabled</translation>
    <translation id="common_desactivated" qtlid="24967">Disabled</translation>
    <translation id="common_not_supported" qtlid="190771">Not supported</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Information about the {0} service has not been found.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Restart the zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">See the details of the errors</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Hide error details</translation>
    <translation id="common_managerv5" qtlid="190784"></translation>
    <translation id="common_managerv3" qtlid="34512"></translation>
    <translation id="global_app_title" qtlid="122131">Your OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">All guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Help centre</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Create a support request</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">My support requests</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Support request</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Email history</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Phone support</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Changelog</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Change my e-mail address </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">For more detailed information, please read <a href="{0}" target="_blank">our guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domains and hosting packages </translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatic renewal user guide </translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Get started with a web hosting package </translation>

--- a/client/app/core/translations/Messages_es_ES.xml
+++ b/client/app/core/translations/Messages_es_ES.xml
@@ -82,7 +82,7 @@
    <translation id="april" qtlid="38181">Abril</translation>
    <translation id="may" qtlid="38421">Mayo</translation>
    <translation id="june" qtlid="38013">Junio</translation>
-   <translation id="jully" qtlid="38085">Julio </translation>
+   <translation id="jully" qtlid="38085">Julio</translation>
    <translation id="august" qtlid="38961">Agosto</translation>
    <translation id="september" qtlid="38409">Septiembre</translation>
    <translation id="october" qtlid="39093">Octubre</translation>
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Volver</translation>
    <translation id="common_next" qtlid="17743">Siguiente</translation>
    <translation id="common_previous" qtlid="17431">Anterior</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Se abrirá en una nueva pestaña</translation>
    <translation id="common_activated" qtlid="30250">Activado</translation>
    <translation id="common_desactivated" qtlid="24967">Desactivado</translation>
    <translation id="common_not_supported" qtlid="190771">No compatible</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">No se ha encontrado la información relativa al servicio {0}.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Restablecer el zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Ver el detalle de los errores</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Ocultar el detalle de los errores</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Su área de cliente Web OVH</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Soporte</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Todas las guías</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centro de ayuda</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Crear una solicitud de asistencia</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Mis solicitudes de asistencia</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Solicitud de asistencia</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Historial de mensajes de correo</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Soporte telefónico</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Historial de actualizaciones</translation>
@@ -454,7 +454,7 @@
    <translation id="country_PG" qtlid="188834">Papúa Nueva Guinea</translation>
    <translation id="country_PH" qtlid="188847">Filipinas</translation>
    <translation id="country_PK" qtlid="188860">Pakistán</translation>
-   <translation id="country_PL" qtlid="40858">Polonia </translation>
+   <translation id="country_PL" qtlid="40858">Polonia</translation>
    <translation id="country_PM" qtlid="188873">San Pedro y Miquelón</translation>
    <translation id="country_PN" qtlid="188886">Pitcairn, Islas</translation>
    <translation id="country_PR" qtlid="188899">Puerto Rico</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Modificar mi dirección de correo </translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Para obtener información más detallada, consulte nuestras <a href="{0}" target="_blank">guías</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Dominios y hosting</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Renovación automática en OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Primeros pasos en un alojamiento compartido </translation>

--- a/client/app/core/translations/Messages_es_US.xml
+++ b/client/app/core/translations/Messages_es_US.xml
@@ -7,8 +7,8 @@
    <translation id="select_product_on_top" qtlid="123499">Veuillez sélectionner un produit à configurer ci-dessus.</translation>
    <translation id="index_nav_bar_logo_alt" qtlid="128190">Manager WEB OVH</translation>
    <translation id="universe_univers-cloud_name" qtlid="15677">Cloud</translation>
-   <translation id="universe_univers-dedicated_name" qtlid="31738">Dédié</translation>
-   <translation id="universe_univers-telecom_name" qtlid="135827">VoIP</translation>
+   <translation id="universe_univers-dedicated_name" qtlid="31738">Dedicado</translation>
+   <translation id="universe_univers-telecom_name" qtlid="135827">Telecom</translation>
    <translation id="universe_univers-web_name" qtlid="135840">Web</translation>
    <translation id="universe_univers-sunrise_name" qtlid="232401">Sunrise</translation>
 <translation id="universe_univers-portal_name" translate="none">MyOVH</translation>
@@ -17,29 +17,29 @@
    <translation id="universe_labs_chatbot" qtlid="382758">Soporte virtual OVH</translation>
    <translation id="older_interface" qtlid="135931">Antiguo panel de control</translation>
 
-   <translation id="language_de" qtlid="31618">Allemand</translation>
-   <translation id="language_en" qtlid="33838">Anglais</translation>
-   <translation id="language_es" qtlid="33454">Espagnol</translation>
-   <translation id="language_fr" qtlid="29684">Français</translation>
-   <translation id="language_pl" qtlid="32746">Polonais</translation>
+   <translation id="language_de" qtlid="31618">Alemán</translation>
+   <translation id="language_en" qtlid="33838">Inglés</translation>
+   <translation id="language_es" qtlid="33454">Español</translation>
+   <translation id="language_fr" qtlid="29684">Francés</translation>
+   <translation id="language_pl" qtlid="32746">Polaco</translation>
    <translation id="language_cz" qtlid="34222">Tchèque</translation>
    <translation id="language_fi" qtlid="33670">Finlandais</translation>
    <translation id="language_ie" qtlid="152089">Irlandés</translation>
-   <translation id="language_it" qtlid="33502">Italien</translation>
-   <translation id="language_lt" qtlid="31222">Lituanien</translation>
-   <translation id="language_nl" qtlid="33982">Néerlandais</translation>
-   <translation id="language_pt" qtlid="30370">Portugais</translation>
-   <translation id="language_uk" qtlid="29071">Royaume-Uni</translation>
+   <translation id="language_it" qtlid="33502">Italiano</translation>
+   <translation id="language_lt" qtlid="31222">Lituano</translation>
+   <translation id="language_nl" qtlid="33982">Holandés</translation>
+   <translation id="language_pt" qtlid="30370">Portugués</translation>
+   <translation id="language_uk" qtlid="29071">Reino Unido</translation>
 
-   <translation id="unit_size_B" qtlid="121975">o</translation>
-   <translation id="unit_size_KB" qtlid="121987">ko</translation>
-   <translation id="unit_size_MB" qtlid="48878">Mo</translation>
-   <translation id="unit_size_GB" qtlid="48890">Go</translation>
-   <translation id="unit_size_TB" qtlid="70121">To</translation>
-   <translation id="unit_size_PB" qtlid="121999">Po</translation>
-   <translation id="unit_size_EB" qtlid="122011">Eo</translation>
-   <translation id="unit_size_ZB" qtlid="122023">Zo</translation>
-   <translation id="unit_size_YB" qtlid="122035">Yo</translation>
+   <translation id="unit_size_B" qtlid="121975">B</translation>
+   <translation id="unit_size_KB" qtlid="121987">KB</translation>
+   <translation id="unit_size_MB" qtlid="48878">MB</translation>
+   <translation id="unit_size_GB" qtlid="48890">GB</translation>
+   <translation id="unit_size_TB" qtlid="70121">TB</translation>
+   <translation id="unit_size_PB" qtlid="121999">PB</translation>
+   <translation id="unit_size_EB" qtlid="122011">EB</translation>
+   <translation id="unit_size_ZB" qtlid="122023">ZB</translation>
+   <translation id="unit_size_YB" qtlid="122035">YB</translation>
    <translation id="unit_size_KiB" qtlid="180252">KiB</translation>
    <translation id="unit_size_MiB" qtlid="180265">MiB</translation>
    <translation id="unit_size_GiB" qtlid="180278">GiB</translation>
@@ -76,42 +76,42 @@
    <translation id="saturday" qtlid="6406">Samedi</translation>
    <translation id="sunday" qtlid="6418">Dimanche</translation>
 
-   <translation id="januar" qtlid="38745">Janvier</translation>
-   <translation id="februar" qtlid="38229">Février</translation>
+   <translation id="januar" qtlid="38745">Enero</translation>
+   <translation id="februar" qtlid="38229">Febrero</translation>
    <translation id="march" qtlid="38985">Mars</translation>
-   <translation id="april" qtlid="38181">Avril</translation>
-   <translation id="may" qtlid="38421">Mai</translation>
-   <translation id="june" qtlid="38013">Juin</translation>
-   <translation id="jully" qtlid="38085">Juillet</translation>
-   <translation id="august" qtlid="38961">Août</translation>
-   <translation id="september" qtlid="38409">Septembre</translation>
-   <translation id="october" qtlid="39093">Octobre</translation>
-   <translation id="november" qtlid="38169">Novembre</translation>
-   <translation id="december" qtlid="37989">Décembre</translation>
+   <translation id="april" qtlid="38181">Abril</translation>
+   <translation id="may" qtlid="38421">Mayo</translation>
+   <translation id="june" qtlid="38013">Junio</translation>
+   <translation id="jully" qtlid="38085">Julio</translation>
+   <translation id="august" qtlid="38961">Agosto</translation>
+   <translation id="september" qtlid="38409">Septiembre</translation>
+   <translation id="october" qtlid="39093">Octubre</translation>
+   <translation id="november" qtlid="38169">Noviembre</translation>
+   <translation id="december" qtlid="37989">Diciembre</translation>
    <translation id="januar_short" qtlid="123511">Janv</translation>
    <translation id="februar_short" qtlid="123523">Févr</translation>
    <translation id="march_short" qtlid="38985">Mars</translation>
-   <translation id="april_short" qtlid="38181">Avril</translation>
-   <translation id="may_short" qtlid="38421">Mai</translation>
-   <translation id="june_short" qtlid="38013">Juin</translation>
+   <translation id="april_short" qtlid="38181">Abril</translation>
+   <translation id="may_short" qtlid="38421">Mayo</translation>
+   <translation id="june_short" qtlid="38013">Junio</translation>
    <translation id="jully_short" qtlid="123535">Juil</translation>
-   <translation id="august_short" qtlid="38961">Août</translation>
-   <translation id="september_short" qtlid="123547">Sept</translation>
+   <translation id="august_short" qtlid="38961">Agosto</translation>
+   <translation id="september_short" qtlid="123547">Sep</translation>
    <translation id="october_short" qtlid="123559">Oct</translation>
    <translation id="november_short" qtlid="123571">Nov</translation>
    <translation id="december_short" qtlid="123583">Déc</translation>
 
    <translation id="wizard_cancel" qtlid="37863">Cancelar</translation>
-   <translation id="wizard_confirm" qtlid="26047">Valider</translation>
+   <translation id="wizard_confirm" qtlid="26047">Aceptar</translation>
    <translation id="wizard_modify" qtlid="37875">Modificar</translation>
    <translation id="wizard_delete" qtlid="2414">Eliminar</translation>
-   <translation id="wizard_yes" qtlid="34776">Oui</translation>
-   <translation id="wizard_no" qtlid="34788">Non</translation>
+   <translation id="wizard_yes" qtlid="34776">Sí</translation>
+   <translation id="wizard_no" qtlid="34788">No</translation>
    <translation id="wizard_close" qtlid="4670">Cerrar</translation>
    <translation id="wizard_order" qtlid="43558">Contratar</translation>
    <translation id="wizard_pay" qtlid="130183">Régler</translation>
-   <translation id="wizard_next" qtlid="17743">Suivant</translation>
-   <translation id="wizard_previous" qtlid="17431">Précédent</translation>
+   <translation id="wizard_next" qtlid="17743">Siguiente</translation>
+   <translation id="wizard_previous" qtlid="17431">Anterior</translation>
    <translation id="wizard_export" qtlid="69881">Exporter</translation>
    <translation id="table_search_noresult" qtlid="433498">No se ha encontrado ningún resultado correspondiente a su criterio de búsqueda.</translation>
    <translation id="table_modify_entry" qtlid="402074">Modificar el registro</translation>
@@ -128,19 +128,19 @@
    <translation id="select_placeholder" qtlid="447963">Seleccione...</translation>
    <translation id="pagination_page" qtlid="503215">Página {{current}} de {{last}}</translation>
    <translation id="pagination_go" qtlid="31522">OK</translation>
-   <translation id="pagination_display" qtlid="69353">Afficher</translation>
+   <translation id="pagination_display" qtlid="69353">Ver</translation>
    <translation id="common_actions" qtlid="72809">Acciones</translation>
    <translation id="common_manage" qtlid="16301">Gestionar</translation>
-   <translation id="common_price" qtlid="83913">Prix</translation>
-   <translation id="common_search" qtlid="37659">Rechercher</translation>
+   <translation id="common_price" qtlid="83913">Precio</translation>
+   <translation id="common_search" qtlid="37659">Buscar</translation>
    <translation id="common_cancel" qtlid="37863">Cancelar</translation>
    <translation id="common_confirm" qtlid="31498">Confirmar</translation>
    <translation id="common_install" qtlid="108709">Installer</translation>
    <translation id="common_loading" qtlid="242769">Cargando...</translation>
-   <translation id="common_back" qtlid="4118">Retour</translation>
-   <translation id="common_next" qtlid="17743">Suivant</translation>
-   <translation id="common_previous" qtlid="17431">Précédent</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_back" qtlid="4118">Volver</translation>
+   <translation id="common_next" qtlid="17743">Siguiente</translation>
+   <translation id="common_previous" qtlid="17431">Anterior</translation>
+   <translation id="common_newtab" qtlid="516549">Se abrirá en una nueva pestaña</translation>
    <translation id="common_activated" qtlid="30250">Activé</translation>
    <translation id="common_desactivated" qtlid="24967">Desactivada</translation>
    <translation id="common_not_supported" qtlid="190771">No compatible</translation>
@@ -154,13 +154,13 @@
    <translation id="common_serviceinfos_error" qtlid="416358">No se han encontrado datos asociados al servicio {0}.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Restablecer el zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Ver el detalle de los errores</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Ocultar el detalle de los errores</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Votre espace client Web OVH</translation>
-   <translation id="global_language" qtlid="30598">Langue</translation>
-   <translation id="global_logout" qtlid="33658">Déconnexion</translation>
-   <translation id="global_changelog" qtlid="124964">Historique des mises à jour</translation>
+   <translation id="global_language" qtlid="30598">Idioma</translation>
+   <translation id="global_logout" qtlid="33658">Salir</translation>
+   <translation id="global_changelog" qtlid="124964">Historial de actualizaciones</translation>
    <translation id="global_preference" qtlid="144708">Mis suscripciones</translation>
    <translation id="global_billing" qtlid="32950">Facturación</translation>
    <translation id="global_billing_history" qtlid="159540">Mis facturas</translation>
@@ -172,7 +172,7 @@
    <translation id="global_account_subscriptions" qtlid="144708">Mis suscripciones</translation>
    <translation id="global_account_ssh" qtlid="165897">Mis claves SSH</translation>
    <translation id="global_account_advanced" qtlid="39958">Paramètres avancés</translation>
-   <translation id="global_support" qtlid="39994">Support</translation>
+   <translation id="global_support" qtlid="39994">Soporte</translation>
    <translation id="global_feedback" qtlid="103558">Donnez votre avis</translation>
    <translation id="global_feedback_appreciation" qtlid="127468">Votre avis nous intéresse</translation>
    <translation id="global_feedback_appreciation_text" qtlid="328758">A través de esta ventana puede darnos su opinión sobre la navegación<br/>y la usabilidad del manager.</translation>
@@ -246,8 +246,8 @@
    <translation id="navigation_left_sharepoint_order" qtlid="298352">Sharepoint</translation>
    <translation id="global_configuration" qtlid="4406">Configuración</translation>
    <translation id="common_other" qtlid="19963">Autre</translation>
-   <translation id="common_yes" qtlid="34776">Oui</translation>
-   <translation id="common_no" qtlid="34788">Non</translation>
+   <translation id="common_yes" qtlid="34776">Sí</translation>
+   <translation id="common_no" qtlid="34788">No</translation>
    <translation id="common_delete" qtlid="2414">Eliminar</translation>
    <translation id="common_configure" qtlid="4010">Configurar</translation>
    <translation id="common_delete_in_progress" qtlid="200300">Eliminando...</translation>
@@ -255,18 +255,18 @@
    <translation id="required_fields" qtlid="433550">Los campos marcados con un asterisco son obligatorios.</translation>
    <translation id="common_skip_to_main_content" qtlid="454052">Ir al contenido principal</translation>
 
-   <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
+   <translation id="common_menu_support_assistance" qtlid="52699">Soporte</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Todas las guías</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centro de ayuda</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Crear un solicitud de soporte</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Lista de solicitudes de soporte</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Solicitud de asistencia</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Historial de correos</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Soporte </translation>
-   <translation id="common_menu_support_changelog" qtlid="124964">Historique des mises à jour</translation>
+   <translation id="common_menu_support_changelog" qtlid="124964">Historial de actualizaciones</translation>
 
-   <translation id="contract_next" qtlid="17743">Suivant</translation>
-   <translation id="contract_previous" qtlid="17431">Précédent</translation>
+   <translation id="contract_next" qtlid="17743">Siguiente</translation>
+   <translation id="contract_previous" qtlid="17431">Anterior</translation>
    <translation id="download_contract" qtlid="503228">Abrir el contrato "{{name}}" en PDF</translation>
    <translation id="contract_help" qtlid="180382">Debe ver los contratos completos para poder validarlos.</translation>
    <translation id="contracts_list_title" qtlid="503241">Hay {{count}} contratos.</translation>
@@ -314,7 +314,7 @@
    <translation id="country_BW" qtlid="187326">Botsuana</translation>
    <translation id="country_BY" qtlid="43762">Biélorussie</translation>
    <translation id="country_BZ" qtlid="187352">Belice</translation>
-   <translation id="country_CA" qtlid="108733">Canada</translation>
+   <translation id="country_CA" qtlid="108733">Canadá</translation>
    <translation id="country_CC" qtlid="187365">Cocos (Keeling), Islas</translation>
    <translation id="country_CD" qtlid="187378">Congo, República Democrática del</translation>
    <translation id="country_CF" qtlid="187391">Centroafricana, República</translation>
@@ -333,7 +333,7 @@
    <translation id="country_CX" qtlid="187547">Christmas, Isla</translation>
    <translation id="country_CY" qtlid="43810">Chypre</translation>
    <translation id="country_CZ" qtlid="40918">République tchèque</translation>
-   <translation id="country_DE" qtlid="29083">Allemagne</translation>
+   <translation id="country_DE" qtlid="29083">Alemania</translation>
    <translation id="country_DJ" qtlid="187560">Yibuti</translation>
    <translation id="country_DK" qtlid="187573">Dinamarca</translation>
    <translation id="country_DM" qtlid="187586">Dominica</translation>
@@ -344,16 +344,16 @@
    <translation id="country_EG" qtlid="187638">Egipto</translation>
    <translation id="country_EH" qtlid="187651">Sahara Occidental</translation>
    <translation id="country_ER" qtlid="187664">Eritrea</translation>
-   <translation id="country_ES" qtlid="29095">Espagne</translation>
+   <translation id="country_ES" qtlid="29095">España</translation>
    <translation id="country_ET" qtlid="187677">Etiopía</translation>
    <translation id="country_FI" qtlid="40942">Finlande</translation>
    <translation id="country_FJ" qtlid="187690">Fiyi</translation>
    <translation id="country_FK" qtlid="187703">Malvinas, Islas (Fakland)</translation>
    <translation id="country_FM" qtlid="187716">Micronesia, Estados Federados de</translation>
    <translation id="country_FO" qtlid="187729">Feroe, Islas</translation>
-   <translation id="country_FR" qtlid="29047">France</translation>
+   <translation id="country_FR" qtlid="29047">Francia</translation>
    <translation id="country_GA" qtlid="187742">Gabón</translation>
-   <translation id="country_GB" qtlid="29071">Royaume-Uni</translation>
+   <translation id="country_GB" qtlid="29071">Reino Unido</translation>
    <translation id="country_GD" qtlid="187755">Granada</translation>
    <translation id="country_GE" qtlid="187768">Georgia</translation>
    <translation id="country_GF" qtlid="187781">Guayana Francesa</translation>
@@ -385,7 +385,7 @@
    <translation id="country_IQ" qtlid="188067">Irak</translation>
    <translation id="country_IR" qtlid="188080">Irán, República Islámica de</translation>
    <translation id="country_IS" qtlid="188093">Islandia</translation>
-   <translation id="country_IT" qtlid="40870">Italie</translation>
+   <translation id="country_IT" qtlid="40870">Italia</translation>
    <translation id="country_JE" qtlid="188106">Jersey</translation>
    <translation id="country_JM" qtlid="188119">Jamaica</translation>
    <translation id="country_JO" qtlid="188132">Jordania</translation>
@@ -454,7 +454,7 @@
    <translation id="country_PG" qtlid="188834">Papúa Nueva Guinea</translation>
    <translation id="country_PH" qtlid="188847">Filipinas</translation>
    <translation id="country_PK" qtlid="188860">Pakistán</translation>
-   <translation id="country_PL" qtlid="40858">Pologne</translation>
+   <translation id="country_PL" qtlid="40858">Polonia</translation>
    <translation id="country_PM" qtlid="188873">San Pedro y Miquelón</translation>
    <translation id="country_PN" qtlid="188886">Pitcairn, Islas</translation>
    <translation id="country_PR" qtlid="188899">Puerto Rico</translation>
@@ -508,7 +508,7 @@
    <translation id="country_TZ" qtlid="189419">Tanzania, República Unida de</translation>
    <translation id="country_UA" qtlid="43774">Ukraine</translation>
    <translation id="country_UG" qtlid="189432">Uganda</translation>
-   <translation id="country_UK" qtlid="29071">Royaume-Uni</translation>
+   <translation id="country_UK" qtlid="29071">Reino Unido</translation>
    <translation id="country_UM" qtlid="189445">Islas menores alejadas de los Estados Unidos</translation>
    <translation id="country_US" qtlid="108396">États-Unis</translation>
    <translation id="country_UY" qtlid="189458">Uruguay</translation>
@@ -545,7 +545,7 @@
    <translation id="ovh_account_alert" qtlid="374906">Su cuenta de prepago tiene un saldo negativo de {2} a {0}. Acceda a la sección de «<a href="{1}">Facturación</a>» para recargarla.</translation>
    <translation id="ovh_account_cb_expire_alert" qtlid="328771">Su tarjeta bancaria por defecto expira en {0} día(s). Acceda a «<a href="{1}">Facturación</a>» para actualizarla.</translation>
    <translation id="ovh_account_cb_expired_alert" qtlid="328784">Su tarjeta bancaria por defecto ha expirado. Acceda a «<a href="{0}">Facturación</a>» para actualizarla.</translation>
-   <translation id="refresh" qtlid="8182">Actualiser</translation>
+   <translation id="refresh" qtlid="8182">Actualizar</translation>
    <translation id="core_new_window" qtlid="222176">Nueva ventana</translation>
    <translation id="core_change_owner" qtlid="271491">Cambiar de propietario</translation>
    <translation id="core_change_owner_order" qtlid="283981">Si desea cambiar el propietario de su dominio, debe generar una orden de pedido directamente en nuestro sitio web.</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Modificar mi dirección de correo electrónico</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Para obtener información más detallada, consulte nuestras <a href="{0}" target="_blank">guías</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Dominios y planes de alojamiento</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Guía para la renovación automática en OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Debutar en el alojamiento compartido</translation>
@@ -606,7 +607,7 @@
    <translation id="sso_modal_user_title" qtlid="315969">Usted estaba conectado como:</translation>
    <translation id="sso_modal_currentuser_title" qtlid="315982">Usted está conectado ahora como:</translation>
    <translation id="sso_modal_disconnected" qtlid="315995">Usted está desconectado ahora.</translation>
-   <translation id="sso_modal_what" qtlid="62558">Que souhaitez-vous faire ?</translation>
+   <translation id="sso_modal_what" qtlid="62558">¿Qué desea hacer?</translation>
    <translation id="sso_modal_action_reload" qtlid="328810">Continuar como <strong>{{name}}</strong></translation>
    <translation id="sso_modal_action_logout" qtlid="316021">Ir a la página de autenticación</translation>
 
@@ -644,8 +645,8 @@
    <translation id="common_criteria_adder_operator_date_isAfter" qtlid="479225">está después de</translation>
    <translation id="common_criteria_adder_operator_options_is" qtlid="479121">es</translation>
    <translation id="common_criteria_adder_operator_options_isNot" qtlid="479134">es diferente de</translation>
-   <translation id="common_criteria_adder_true_label" qtlid="34776">Oui</translation>
-   <translation id="common_criteria_adder_false_label" qtlid="34788">Non</translation>
+   <translation id="common_criteria_adder_true_label" qtlid="34776">Sí</translation>
+   <translation id="common_criteria_adder_false_label" qtlid="34788">No</translation>
    <translation id="common_criteria_adder_value_label" qtlid="47548">Valeur</translation>
    <translation id="common_criteria_adder_submit_label" qtlid="37923">Añadir</translation>
 
@@ -681,6 +682,6 @@
    <translation id="common_stepper_optional_label" qtlid="488081">(opcional)</translation>
    <translation id="common_stepper_modify_this_step" qtlid="480922">Modificar este paso</translation>
    <translation id="common_stepper_skip_this_step" qtlid="230127">Omitir este paso</translation>
-   <translation id="common_stepper_next_button_label" qtlid="17743">Suivant</translation>
+   <translation id="common_stepper_next_button_label" qtlid="17743">Siguiente</translation>
    <translation id="common_stepper_submit_button_label" qtlid="113382">Soumettre</translation>
 </translations>

--- a/client/app/core/translations/Messages_fi_FI.xml
+++ b/client/app/core/translations/Messages_fi_FI.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Takaisin</translation>
    <translation id="common_next" qtlid="17743">Seuraava</translation>
    <translation id="common_previous" qtlid="17431">Edellinen</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">S'ouvre dans un nouvel onglet</translation>
    <translation id="common_activated" qtlid="30250">Aktivoitu</translation>
    <translation id="common_desactivated" qtlid="24967">Deaktivoitu</translation>
    <translation id="common_not_supported" qtlid="190771">Ei tuettu</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">{0}-palvelua koskevia tietoja ei löydy.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Nollaa zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Katso virheilmoituksien yksityiskohdat</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Masquer le détail des erreurs</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Hallinta v3</translation>
    <translation id="global_app_title" qtlid="122131">OVH:n WEB-hallintapaneeli</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Tuki</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Kaikki ohjeet</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centre d'aide</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Luo tukipyyntö</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Katso kaikki tukipyynnöt</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Demande d'assistance</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Sähköpostihistoria</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Puhelintuki</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Päivityshistoria</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Muuta sähköpostiosoitetta</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Lisätietoja löydät <a href="{0}" target="_blank">oppaistamme</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Verkkotunnukset ja webhotellit</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Käyttöopas automaattisen uusinnan tekemiseen</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Aloita webhotellin käyttö</translation>

--- a/client/app/core/translations/Messages_fr_CA.xml
+++ b/client/app/core/translations/Messages_fr_CA.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Retour</translation>
    <translation id="common_next" qtlid="17743">Suivant</translation>
    <translation id="common_previous" qtlid="17431">Précédent</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">S'ouvre dans un nouvel onglet</translation>
    <translation id="common_activated" qtlid="30250">Activé</translation>
    <translation id="common_desactivated" qtlid="24967">Désactivé</translation>
    <translation id="common_not_supported" qtlid="190771">Non supporté</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Les informations concernant le service {0} n'ont pas été retrouvées.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Réinitialiser le zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Voir le détail des erreurs</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Masquer le détail des erreurs</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Votre espace client du site OVH</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Tous les guides</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centre d'aide</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Créer une demande d'assistance</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Liste de mes demandes d'assistance</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Demande d'assistance</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Historique des courriels</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Assistance téléphonique</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Historique des mises à jour</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Modifier mon adresse courriel</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Pour obtenir des informations plus détaillées, veuillez consulter <a href="{0}" target="_blank">nos guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domaines et Hébergements</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Guide d'utilisation du renouvellement automatique OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Débuter sur un hébergement web</translation>

--- a/client/app/core/translations/Messages_fr_FR.xml
+++ b/client/app/core/translations/Messages_fr_FR.xml
@@ -563,7 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Modifier mon adresse e-mail</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Pour obtenir des informations plus détaillées, veuillez consulter <a href="{0}" target="_blank">nos guides</a>.</translation>
-   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
+   <translation id="core_top_guides_header_fr" qtlid="517725">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domaines et Hébergements</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Guide d'utilisation du renouvellement automatique OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Débuter sur un hébergement web</translation>

--- a/client/app/core/translations/Messages_fr_FR.xml
+++ b/client/app/core/translations/Messages_fr_FR.xml
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Modifier mon adresse e-mail</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Pour obtenir des informations plus détaillées, veuillez consulter <a href="{0}" target="_blank">nos guides</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domaines et Hébergements</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Guide d'utilisation du renouvellement automatique OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Débuter sur un hébergement web</translation>

--- a/client/app/core/translations/Messages_it_IT.xml
+++ b/client/app/core/translations/Messages_it_IT.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Ritorna</translation>
    <translation id="common_next" qtlid="17743">Seguente</translation>
    <translation id="common_previous" qtlid="17431">Precedente</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Apri in una nuova scheda</translation>
    <translation id="common_activated" qtlid="30250">Attivo</translation>
    <translation id="common_desactivated" qtlid="24967">Disattivo</translation>
    <translation id="common_not_supported" qtlid="190771">Non supportato</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Impossibile trovare le informazioni relative al servizio {0}.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Reinizializza lo zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Visualizza il dettaglio degli errori</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Nascondi il dettaglio degli errori</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Il tuo spazio cliente Web OVH</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Supporto</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Tutte le guide</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centro di assistenza</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Crea una richiesta di supporto</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Lista delle tue richieste di supporto</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Richiesta di assistenza</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Storico delle tue email</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Supporto telefonico</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Cronologia aggiornamenti</translation>
@@ -569,6 +569,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Modifica il tuo indirizzo email</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Per maggiori informazioni, consulta le <a href="{0}" target="_blank">nostre guide</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domini e Hosting</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Guida al rinnovo automatico OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Come utilizzare il tuo hosting Web</translation>

--- a/client/app/core/translations/Messages_lt_LT.xml
+++ b/client/app/core/translations/Messages_lt_LT.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Atgal</translation>
    <translation id="common_next" qtlid="17743">Toliau</translation>
    <translation id="common_previous" qtlid="17431">Ankstesnis</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">S'ouvre dans un nouvel onglet</translation>
    <translation id="common_activated" qtlid="30250">Įjungta</translation>
    <translation id="common_desactivated" qtlid="24967">Išjungta</translation>
    <translation id="common_not_supported" qtlid="190771">Nepalaikomas</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Duomenys apie {0} paslaugą nerasti.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Iš naujo inicijuoti mastelį</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Peržiūrėti informaciją apie klaidas</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Masquer le détail des erreurs</translation>
    <translation id="common_managerv5" qtlid="190784">Tvarkytuvas V5</translation>
    <translation id="common_managerv3" qtlid="34512">Tvarkytuvas V3</translation>
    <translation id="global_app_title" qtlid="122131">OVH web valdymo sąsaja</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Pagalba</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Visi gidai</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centre d'aide</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Sukurti pagalbos užklausą</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Mano pagalbos užklausų sąrašas</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Demande d'assistance</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">El. laiškų istorija</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Pagalba telefonu</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Atnaujinimų istorija</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Keisti mano el. pašto adresą</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Išsamesnė informacija pateikta <a href="{0}" target="_blank">mūsų giduose</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domenai ir svetainių talpinimas</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">OVH automatinio atnaujinimo gidas</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Svetainių talpinimo naudojimo pradžia</translation>

--- a/client/app/core/translations/Messages_nl_NL.xml
+++ b/client/app/core/translations/Messages_nl_NL.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Terug</translation>
    <translation id="common_next" qtlid="17743">Volgende</translation>
    <translation id="common_previous" qtlid="17431">Vorige</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Openen in een nieuw tabblad</translation>
    <translation id="common_activated" qtlid="30250">Geactiveerd</translation>
    <translation id="common_desactivated" qtlid="24967">Gedeactiveerd</translation>
    <translation id="common_not_supported" qtlid="190771">Geen support</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Informatie over de {0} dienst is niet beschikbaar. </translation>
    <translation id="common_reset_zoom" qtlid="142237">De 'zoom' resetten</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">De fouten in detail bekijken</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Foutgegevens verbergen</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Uw OVH Web Control Panel</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Support</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Alle handleidingen</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Hulpcentrum</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Maak een aanvraag ter assistentie aan</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Overzicht van mijn aanvragen ter assistentie</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Ondersteuningsverzoek</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">E-mail geschiedenis</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Telefonische assistentie</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Updates geschiedenis</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Wijzig mijn e-mailadres</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Meer informatie vindt u in <a href="{0}" target="_blank">onze handleidingen</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domeinen en Hosting</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Handleiding OVH automatische verlenging</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Ga aan de slag met een webhosting pakket</translation>

--- a/client/app/core/translations/Messages_pl_PL.xml
+++ b/client/app/core/translations/Messages_pl_PL.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Powrót</translation>
    <translation id="common_next" qtlid="17743">Dalej</translation>
    <translation id="common_previous" qtlid="17431">Wstecz</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Otworzy się w nowej zakładce</translation>
    <translation id="common_activated" qtlid="30250">Aktywny</translation>
    <translation id="common_desactivated" qtlid="24967">Wyłączony</translation>
    <translation id="common_not_supported" qtlid="190771">Nie obsługiwane</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">Nie odnaleziono informacji dotyczących usługi {0}.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Resetuj zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Wyświetl szczegóły błędów</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Ukryj szczegóły dotyczące błędów</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">Twój Panel klienta OVH</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Pomoc</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Wszystkie przewodniki</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centrum pomocy</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Otwórz zgłoszenie</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Lista moich zgłoszeń</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Prośba o wsparcie</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Historia e-maili</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Pomoc telefoniczna</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Historia aktualizacji</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Zmień adres e-mail</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Aby uzyskać szczegółowe informacje, sprawdź <a href="{0}" target="_blank">nasze przewodniki</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domeny i Hosting</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Przewodnik na temat automatycznego odnowienia w OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Pierwsze kroki z hostingiem WWW</translation>

--- a/client/app/core/translations/Messages_pt_PT.xml
+++ b/client/app/core/translations/Messages_pt_PT.xml
@@ -140,7 +140,7 @@
    <translation id="common_back" qtlid="4118">Retroceder</translation>
    <translation id="common_next" qtlid="17743">Seguinte</translation>
    <translation id="common_previous" qtlid="17431">Anterior</translation>
-   <translation id="common_newtab">S'ouvre dans un nouvel onglet</translation>
+   <translation id="common_newtab" qtlid="516549">Abre-se numa nova janela</translation>
    <translation id="common_activated" qtlid="30250">Ativado</translation>
    <translation id="common_desactivated" qtlid="24967">Desativado</translation>
    <translation id="common_not_supported" qtlid="190771">Não suportado</translation>
@@ -154,7 +154,7 @@
    <translation id="common_serviceinfos_error" qtlid="416358">As informações relativas ao serviço {0} não foram encontradas.</translation>
    <translation id="common_reset_zoom" qtlid="142237">Reiniciar o zoom</translation>
    <translation id="common_alerts_message_see_more" qtlid="140677">Ver detalhes dos erros</translation>
-   <translation id="common_alerts_message_see_less">Masquer le détail des erreurs</translation>
+   <translation id="common_alerts_message_see_less" qtlid="516562">Ocultar detalhes dos erros</translation>
    <translation id="common_managerv5" qtlid="190784">Manager V5</translation>
    <translation id="common_managerv3" qtlid="34512">Manager V3</translation>
    <translation id="global_app_title" qtlid="122131">O seu espaço cliente Web OVH</translation>
@@ -257,10 +257,10 @@
 
    <translation id="common_menu_support_assistance" qtlid="52699">Assistência</translation>
    <translation id="common_menu_support_all_guides" qtlid="260788">Manuais OVH</translation>
-   <translation id="common_menu_support_help_center">Centre d'aide</translation>
+   <translation id="common_menu_support_help_center" qtlid="516575">Centro de ajuda</translation>
    <translation id="common_menu_support_new_ticket" qtlid="260801">Criar um ticket</translation>
    <translation id="common_menu_support_list_ticket" qtlid="260814">Lista de tickets</translation>
-   <translation id="common_menu_support_ask_for_assistance">Demande d'assistance</translation>
+   <translation id="common_menu_support_ask_for_assistance" qtlid="516588">Pedido de assistência</translation>
    <translation id="common_menu_support_email_history" qtlid="260091">Histórico dos e-mails</translation>
    <translation id="common_menu_support_telephony_contact" qtlid="260827">Assistência telefónica</translation>
    <translation id="common_menu_support_changelog" qtlid="124964">Histórico das atualizações</translation>
@@ -563,6 +563,7 @@
    <translation id="core_email_voila_update_info" qtlid="271790">Alterar o meu endereço de e-mail</translation>
 
    <translation id="core_top_guides_header" qtlid="328797">Para obter informações mais detalhadas queira consultar <a href="{0}" target="_blank">os nossos guias</a>.</translation>
+   <translation id="core_top_guides_header_fr">Pour obtenir une assistance ou des informations détaillées sur vos services et l’état de vos services, rendez-vous sur la page :</translation>
    <translation id="core_type_of_guide_domainHosting" qtlid="290733">Domínios e Alojamentos</translation>
    <translation id="core_top_guide_1_title" qtlid="282432">Guia de utilização da renovação automática OVH</translation>
    <translation id="core_top_guide_2_title" qtlid="282445">Dar os primeiros passos com um alojamento Web</translation>

--- a/client/app/domain/domain.controller.js
+++ b/client/app/domain/domain.controller.js
@@ -9,6 +9,7 @@ angular.module('App').controller(
       $timeout,
       $translate,
       Alerter,
+      constants,
       Domain,
       Hosting,
       User,
@@ -21,6 +22,7 @@ angular.module('App').controller(
       this.$timeout = $timeout;
       this.$translate = $translate;
       this.Alerter = Alerter;
+      this.constants = constants;
       this.Domain = Domain;
       this.Hosting = Hosting;
       this.User = User;
@@ -94,12 +96,18 @@ angular.module('App').controller(
           } else if (alldomOrder) {
             this.alldomURL = `${alldomOrder}${domain.domain}`;
           }
+          this.getGuides(user.ovhSubsidiary);
         })
         .catch(() => {
           this.isAdmin = false;
         });
 
       this.loadDomain();
+    }
+
+    getGuides(subsidiary) {
+      this.autorenewGuide = _.get(this.constants, `urls.${subsidiary}.guides.autoRenew`, this.constants.urls.FR.guides.autoRenew);
+      this.autorenewUrl = `${this.constants.AUTORENEW_URL}?selectedType=DOMAIN&searchText=${this.domainInfos.domain}`;
     }
 
     loadDomain() {

--- a/client/app/domain/domain.controller.js
+++ b/client/app/domain/domain.controller.js
@@ -75,7 +75,7 @@ angular.module('App').controller(
       });
       this.$scope.$on('$destroy', () => this.Domain.killDomainPolling());
 
-      this.$q
+      return this.$q
         .all({
           user: this.User.getUser(),
           domain: this.Domain.getServiceInfo(this.$stateParams.productId),
@@ -100,9 +100,8 @@ angular.module('App').controller(
         })
         .catch(() => {
           this.isAdmin = false;
-        });
-
-      this.loadDomain();
+        })
+        .finally(() => this.loadDomain());
     }
 
     getGuides(subsidiary) {

--- a/client/app/domain/domain.controller.js
+++ b/client/app/domain/domain.controller.js
@@ -2,29 +2,29 @@ angular.module('App').controller(
   'DomainCtrl',
   class DomainCtrl {
     constructor(
-      $scope,
-      $rootScope,
       $q,
+      $rootScope,
+      $scope,
       $stateParams,
       $timeout,
       $translate,
       Alerter,
-      WucAllDom,
       Domain,
       Hosting,
       User,
+      WucAllDom,
     ) {
-      this.$scope = $scope;
-      this.$rootScope = $rootScope;
       this.$q = $q;
+      this.$rootScope = $rootScope;
+      this.$scope = $scope;
       this.$stateParams = $stateParams;
       this.$timeout = $timeout;
       this.$translate = $translate;
       this.Alerter = Alerter;
-      this.WucAllDom = WucAllDom;
       this.Domain = Domain;
       this.Hosting = Hosting;
       this.User = User;
+      this.WucAllDom = WucAllDom;
     }
 
     $onInit() {

--- a/client/app/domain/domain.html
+++ b/client/app/domain/domain.html
@@ -90,6 +90,11 @@
                       menu="ctrlDomainTabs.tabMenu"
                       tr="tr"></wuc-ovh-tabs>
             <div class="tab-content">
+                <wuc-autorenew-invite data-product-type="domain"
+                                      data-service-infos="ctrlDomain.domainInfos"
+                                      data-guide-url="{{:: ctrlDomain.autorenewGuide }}"
+                                      data-autorenew-url="{{:: ctrlDomain.autorenewUrl }}">
+                </wuc-autorenew-invite>
                 <div data-ovh-alert="{{alerts.tabs}}"></div>
 
                 <div class="tab-pane active domain"

--- a/client/app/domain/domain.html
+++ b/client/app/domain/domain.html
@@ -90,7 +90,8 @@
                       menu="ctrlDomainTabs.tabMenu"
                       tr="tr"></wuc-ovh-tabs>
             <div class="tab-content">
-                <wuc-autorenew-invite data-product-type="domain"
+                <wuc-autorenew-invite data-ng-if="!ctrlDomain.isAllDom"
+                                      data-product-type="domain"
                                       data-service-infos="ctrlDomain.domainInfos"
                                       data-guide-url="{{:: ctrlDomain.autorenewGuide }}"
                                       data-autorenew-url="{{:: ctrlDomain.autorenewUrl }}">

--- a/client/app/domain/translations/Messages_es_US.xml
+++ b/client/app/domain/translations/Messages_es_US.xml
@@ -306,7 +306,7 @@
    <translation id="domain_configuration_whois_title_button" qtlid="124447">Configurer le WHOIS</translation>
    <translation id="domain_configuration_whois_title" qtlid="124447">Configurer le WHOIS</translation>
    <translation id="domain_configuration_whois_step1_question" qtlid="435044">Elija si desea que sus datos personales se muestren o se oculten en el registro WHOIS para el dominio {0}.</translation>
-   <translation id="domain_configuration_whois_step1_display" qtlid="69353">Afficher</translation>
+   <translation id="domain_configuration_whois_step1_display" qtlid="69353">Ver</translation>
    <translation id="domain_configuration_whois_step1_hide" qtlid="97136">Masquer</translation>
    <translation id="domain_configuration_whois_step1_helpwizard_title" qtlid="130075">OWO</translation>
    <translation id="domain_configuration_whois_step1_helpwizard_desc" qtlid="329005">Cuando se registra un dominio, se solicita información personal que por defecto es publicada en la base de datos WHOIS, que es pública. <br/>Esta función le permite ocultar esa información si así lo desea.</translation>
@@ -595,7 +595,7 @@
    <translation id="domain_configuration_dns_entry_add_servicetypes" qtlid="192409">Tipos de servicio</translation>
    <translation id="domain_configuration_dns_entry_add_servicetypes_all" qtlid="69173">Tous</translation>
    <translation id="domain_configuration_dns_entry_add_servicetypes_email" qtlid="436944">Email</translation>
-   <translation id="domain_configuration_dns_entry_add_servicetypes_none" qtlid="30646">Aucun</translation>
+   <translation id="domain_configuration_dns_entry_add_servicetypes_none" qtlid="30646">Ninguno</translation>
    <translation id="domain_configuration_dns_entry_add_t_y" qtlid="192435">Modo de prueba</translation>
    <translation id="domain_configuration_dns_entry_add_t_y_no" qtlid="24967">Desactivada</translation>
    <translation id="domain_configuration_dns_entry_add_t_y_yes" qtlid="30250">Activé</translation>
@@ -612,7 +612,7 @@
    <translation id="domain_configuration_dns_entry_add_spf_all_title" qtlid="192552">¿La información que ha indicado describe todos los hosts que envían correo de {0}?</translation>
    <translation id="domain_configuration_dns_entry_add_spf_all_title_yes" qtlid="192565">Sí, estoy seguro</translation>
    <translation id="domain_configuration_dns_entry_add_spf_all_title_safe" qtlid="192578">Sí, pero utilizar el safe mode</translation>
-   <translation id="domain_configuration_dns_entry_add_spf_all_title_no" qtlid="34788">Non</translation>
+   <translation id="domain_configuration_dns_entry_add_spf_all_title_no" qtlid="34788">No</translation>
    <translation id="domain_configuration_dns_entry_add_tlsa_usage" qtlid="109974">Usage</translation>
    <translation id="domain_configuration_dns_entry_add_tlsa_selector" qtlid="291669">Selector</translation>
    <translation id="domain_configuration_dns_entry_add_tlsa_matching_type" qtlid="291682">Tipo de correspondencia</translation>
@@ -783,7 +783,7 @@
    <translation id="domain_configuration_web_hosting_sqlPerso_header" qtlid="492016">MySQL Personal</translation>
    <translation id="domain_configuration_web_hosting_sqlPro_header" qtlid="492029">MySQL Profesional</translation>
    <translation id="domain_configuration_web_hosting_privateSql_header" qtlid="72845">SQL Privé</translation>
-   <translation id="domain_configuration_web_hosting_price_header" qtlid="83913">Prix</translation>
+   <translation id="domain_configuration_web_hosting_price_header" qtlid="83913">Precio</translation>
    <translation id="domain_configuration_web_hosting_choose_offer" qtlid="233313">Seleccione el producto que desea contratar</translation>
    <translation id="domain_configuration_web_hosting_choose_module" qtlid="287632">Seleccione un módulo preinstalado por nosotros:</translation>
    <translation id="domain_configuration_web_hosting_choose_offer_explain" qtlid="329473">Para más información sobre nuestros productos y para consultar sus especificaciones técnicas y las distintas opciones, visite <a href="{0}" target="_blank">nuestro sitio web</a>.</translation>
@@ -814,7 +814,7 @@
 
    <translation id="domain_configuration_create_site" qtlid="288548">Crear mi sitio </translation>
    <translation id="domain_update_owner_cancel" qtlid="37863">Cancelar</translation>
-   <translation id="domain_update_owner_ok" qtlid="26047">Valider</translation>
+   <translation id="domain_update_owner_ok" qtlid="26047">Aceptar</translation>
    <translation id="domain_update_owner_edit" qtlid="37875">Modificar</translation>
 
 
@@ -851,7 +851,7 @@
    <translation id="domain_update_owner_nationality" qtlid="38073">Nationalité</translation>
    <translation id="domain_update_owner_spareemail" qtlid="92153">Email de secours</translation>
    <translation id="domain_update_owner_cancel" qtlid="37863">Cancelar</translation>
-   <translation id="domain_update_owner_OK" qtlid="26047">Valider</translation>
+   <translation id="domain_update_owner_OK" qtlid="26047">Aceptar</translation>
    <translation id="domain_update_owner_gender" qtlid="267175">Sexo</translation>
    <translation id="domain_update_owner_gender_female" qtlid="267188">Femenino</translation>
    <translation id="domain_update_owner_gender_male" qtlid="267201">Masculino</translation>

--- a/client/app/domains/translations/Messages_es_US.xml
+++ b/client/app/domains/translations/Messages_es_US.xml
@@ -51,7 +51,7 @@
    <translation id="domains_configuration_whois_step1_unable_to_configure" qtlid="140794">El WHOIS no puede modificarse en algunos de los dominios seleccionados (<span class="italic">{0}</span>).</translation>
    <translation id="domains_configuration_whois_step1_unable_ignored" qtlid="140807">Esos dominios se ignorarán al realizar las modificaciones.</translation>
    <translation id="domains_configuration_whois_step1_question" qtlid="140820">Por favor, indique si quiere que sus datos personales se muestren o se oculten en el registro WHOIS para los dominios seleccionados</translation>
-   <translation id="domains_configuration_whois_step1_display" qtlid="69353">Afficher</translation>
+   <translation id="domains_configuration_whois_step1_display" qtlid="69353">Ver</translation>
    <translation id="domains_configuration_whois_step1_hide" qtlid="97136">Masquer</translation>
    <translation id="domains_configuration_whois_step1_helpwizard_title" qtlid="130075">OWO</translation>
    <translation id="domains_configuration_whois_step1_helpwizard_desc" qtlid="329499">Cuando se registra un dominio, se solicita información personal que por defecto es publicada en la base de datos WHOIS, que es pública.<br/>Esta función le permite ocultar esa información si lo desea.</translation>
@@ -121,10 +121,10 @@
    <translation id="domains_newdnszone_order_step2_title" qtlid="263259">2. Detalles</translation>
    <translation id="domains_newdnszone_order_step2_domain" qtlid="263207">Nombre de la zona DNS</translation>
    <translation id="domains_newdnszone_order_step2_description" qtlid="9238">Descripción</translation>
-   <translation id="domains_newdnszone_order_step2_price" qtlid="83913">Prix</translation>
+   <translation id="domains_newdnszone_order_step2_price" qtlid="83913">Precio</translation>
    <translation id="domains_newdnszone_order_step2_minimized" qtlid="263897">¿Desea activar las entradas mínimas?</translation>
-   <translation id="domains_newdnszone_order_step2_minimized_yes" qtlid="34776">Oui</translation>
-   <translation id="domains_newdnszone_order_step2_minimized_no" qtlid="34788">Non</translation>
+   <translation id="domains_newdnszone_order_step2_minimized_yes" qtlid="34776">Sí</translation>
+   <translation id="domains_newdnszone_order_step2_minimized_no" qtlid="34788">No</translation>
    <translation id="domains_newdnszone_order_step3_title" qtlid="186089">3. Validación</translation>
    <translation id="domains_newdnszone_order_step3_question" qtlid="263272">Haga clic en  "Generar orden de pedido" para contratar la zona DNS.</translation>
    <translation id="domains_newdnszone_order_step3_contracts_ask" qtlid="161646">Lea y acepte los siguientes contratos y haga clic en «Siguiente»:</translation>

--- a/client/app/hosting/hosting.controller.js
+++ b/client/app/hosting/hosting.controller.js
@@ -441,6 +441,13 @@ angular
         HostingDomain.killAllPolling();
       });
 
+      function getAutorenewUrl(guides) {
+        $scope.autorenew = {
+          guide: guides.autorenew,
+          url: `${constants.AUTORENEW_URL}?selectedType=HOSTING_WEB&searchText=${$scope.hosting.serviceInfos.domain}`,
+        };
+      }
+
       function loadHosting() {
         return Hosting.getSelected($stateParams.productId, true)
           .then(
@@ -520,6 +527,8 @@ angular
                 default:
                   break;
               }
+
+              getAutorenewUrl(guides);
             }
           })
           .then(() => {

--- a/client/app/hosting/hosting.html
+++ b/client/app/hosting/hosting.html
@@ -98,6 +98,12 @@
               menu="ctrlHostingTabs.tabMenu"
               tr="tr"></wuc-ovh-tabs>
     <div class="tab-content">
+        <wuc-autorenew-invite data-product-type="hosting"
+                              data-service-infos="hosting.serviceInfos"
+                              data-guide-url="{{:: autorenew.guide }}"
+                              data-autorenew-url="{{:: autorenew.url }}">
+        </wuc-autorenew-invite>
+
         <div data-ovh-alert="{{alerts.tabs}}"></div>
 
         <div class="alert alert-dismissible alert-info" role="alert"

--- a/client/app/hosting/translations/Messages_cs_CZ.xml
+++ b/client/app/hosting/translations/Messages_cs_CZ.xml
@@ -349,7 +349,7 @@ Dále je zakázáno přistupovat k nadřazené složce pomocí ..</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Vytváření...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Odstraňování...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accéder à l'interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Résilier l'abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Êtes-vous sûr de vouloir résilier votre abonnement «Visibilité Pro» pour le compte suivant ?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La suppression de l'abonnement «Visibilité Pro» a bien été prise en compte.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Une erreur est survenue lors de la suppression de votre abonnement «Visibilité Pro».</translation>

--- a/client/app/hosting/translations/Messages_de_DE.xml
+++ b/client/app/hosting/translations/Messages_de_DE.xml
@@ -267,7 +267,7 @@
    <translation id="hosting_tab_CRON_table_header_language" qtlid="145644">Sprache</translation>
    <translation id="hosting_tab_CRON_table_header_frequency" qtlid="30442">Frequenz</translation>
    <translation id="hosting_tab_CRON_table_header_description" qtlid="9238">Beschreibung</translation>
-   <translation id="hosting_tab_CRON_table_header_command" qtlid="8302">Befehl</translation>
+   <translation id="hosting_tab_CRON_table_header_command" qtlid="8302">Bestellung</translation>
    <translation id="hosting_tab_CRON_table_language_OTHER" qtlid="19963">Andere</translation>
    <translation id="hosting_tab_CRON_table_language_other" qtlid="19963">Andere</translation>
    <translation id="hosting_tab_CRON_table_language_PHP_4" qtlid="196686">PHP 4</translation>
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Erstellung wird durchgeführt</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Löschung wird durchgeführt</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Zum Interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Abonnement kündigen</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Sind Sie sicher, dass Sie Ihr „Visibility Pro" Abonnement für den folgenden Account kündigen möchten?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Die Kündigungsanfrage Ihres „Visibility Pro" Abonnements wurde registriert.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Bei der Kündigung Ihres „Visibility Pro" Abonnements ist ein Fehler aufgetreten.</translation>

--- a/client/app/hosting/translations/Messages_en_ASIA.xml
+++ b/client/app/hosting/translations/Messages_en_ASIA.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creating...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Deleting...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Access the interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancel subscription</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Are you sure you want to cancel your Visibility Pro account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Your cancellation request for this Visibility Pro account has been successfully submitted.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">An error has occurred submitting your cancellation request for this account.</translation>

--- a/client/app/hosting/translations/Messages_en_AU.xml
+++ b/client/app/hosting/translations/Messages_en_AU.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creating...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Deleting...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Access the interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancel subscription</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Are you sure you want to cancel your Visibility Pro account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Your cancellation request for this Visibility Pro account has been successfully submitted.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">An error has occurred submitting your cancellation request for this account.</translation>

--- a/client/app/hosting/translations/Messages_en_CA.xml
+++ b/client/app/hosting/translations/Messages_en_CA.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creating...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Deleting...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Access the interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancel subscription</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Are you sure you want to cancel your Visibility Pro account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Your cancellation request for this Visibility Pro account has been successfully submitted.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">An error has occurred submitting your cancellation request for this account.</translation>

--- a/client/app/hosting/translations/Messages_en_GB.xml
+++ b/client/app/hosting/translations/Messages_en_GB.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creating...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Deleting...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Access the interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancel subscription</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Are you sure you want to cancel your Visibility Pro account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Your cancellation request for this Visibility Pro account has been successfully submitted.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">An error has occurred submitting your cancellation request for this account.</translation>

--- a/client/app/hosting/translations/Messages_en_SG.xml
+++ b/client/app/hosting/translations/Messages_en_SG.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creating...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Deleting...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Access the interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancel subscription</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Are you sure you want to cancel your Visibility Pro account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Your cancellation request for this Visibility Pro account has been successfully submitted.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">An error has occurred submitting your cancellation request for this account.</translation>

--- a/client/app/hosting/translations/Messages_en_US.xml
+++ b/client/app/hosting/translations/Messages_en_US.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creating...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Deleting...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Access the interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancel subscription</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Are you sure you want to cancel your Visibility Pro account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Your cancellation request for this Visibility Pro account has been successfully submitted.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">An error has occurred submitting your cancellation request for this account.</translation>

--- a/client/app/hosting/translations/Messages_es_ES.xml
+++ b/client/app/hosting/translations/Messages_es_ES.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creando...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Eliminando...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Acceder al panel</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Dar de baja la suscripción</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">¿Seguro que quiere dar de baja la suscripción «Visibilidad Pro» para la siguiente cuenta?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La solicitud de eliminación de la suscripción «Visibilidad Pro» se ha enviado.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Se ha producido un error al eliminar la suscripción «Visibilidad Pro».</translation>

--- a/client/app/hosting/translations/Messages_es_US.xml
+++ b/client/app/hosting/translations/Messages_es_US.xml
@@ -34,7 +34,7 @@
    <translation id="hosting_dashboard_service_main_domain_change" qtlid="284384">Cambiar el dominio principal</translation>
    <translation id="hosting_dashboard_service_regenerate_ssl_success" qtlid="315722">La solicitud de regeneración del certificado se ha enviado.</translation>
    <translation id="hosting_dashboard_service_regenerate_ssl_error" qtlid="434161">Se ha producido un error al solicitar la regeneración del certificado.</translation>
-   <translation id="hosting_dashboard_disk_usage" qtlid="28159">Espace disque</translation>
+   <translation id="hosting_dashboard_disk_usage" qtlid="28159">Espacio en disco</translation>
    <translation id="hosting_dashboard_disk_total" qtlid="252776">Capacidad del disco:</translation>
    <translation id="hosting_dashboard_disk_available_total" qtlid="492392">Espacio disponible</translation>
    <translation id="hosting_dashboard_disk_usage_total" qtlid="109129">Espace utilisé :</translation>
@@ -157,7 +157,7 @@
    <translation id="hosting_dashboard_add_or_order_step1_order" qtlid="284763">Contratar un nuevo dominio</translation>
    <translation id="hosting_dashboard_add_or_order_step1_attach" qtlid="284776">Asociar un dominio existente</translation>
 
-   <translation id="hosting_dashboard_service_ssl" qtlid="21451">Certificat SSL</translation>
+   <translation id="hosting_dashboard_service_ssl" qtlid="21451">Certificado SSL</translation>
    <translation id="hosting_dashboard_service_cdn" qtlid="402659">Opción CDN + HTTP/2</translation>
    <translation id="hosting_dashboard_service_web" qtlid="223489">Sitios web</translation>
    <translation id="hosting_dashboard_service_privatesql" qtlid="215429">Base de datos privada</translation>
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creando...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Eliminando...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Acceder a la interfaz</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancelar la suscripción</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">¿Está seguro(a) de que desea cancelar la suscripción «Visibilidad Pro» para la siguiente cuenta?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La solicitud de eliminación de la suscripción «Visibilidad Pro» se ha enviado correctamente.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Se ha producido un error al eliminar la suscripción «Visibilidad Pro».</translation>
@@ -1049,7 +1049,7 @@
    <translation id="hosting_tab_FTP_configuration_user_create_iisRemoteRights_read" qtlid="198961">READ</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_iisRemoteRights_RW" qtlid="198974">RW</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_iisRemoteRights_rw" qtlid="198974">RW</translation>
-   <translation id="hosting_tab_FTP_configuration_user_create_iisRemoteRights_none" qtlid="30646">Aucun</translation>
+   <translation id="hosting_tab_FTP_configuration_user_create_iisRemoteRights_none" qtlid="30646">Ninguno</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_step1_webDavRights_label" qtlid="198987">Permisos de WebDAV</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_OFF" qtlid="126368">OFF</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_READ" qtlid="198961">READ</translation>
@@ -1057,7 +1057,7 @@
    <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_off" qtlid="126368">OFF</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_read" qtlid="198961">READ</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_rw" qtlid="198974">RW</translation>
-   <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_none" qtlid="30646">Aucun</translation>
+   <translation id="hosting_tab_FTP_configuration_user_create_webDavRights_none" qtlid="30646">Ninguno</translation>
 
    <translation id="hosting_tab_FTP_configuration_user_create_step2_password_question" qtlid="199000">Seleccione la contraseña del usuario</translation>
    <translation id="hosting_tab_FTP_configuration_user_create_step2_password_password" qtlid="2270">Contraseña</translation>
@@ -1095,7 +1095,7 @@
    <translation id="hosting_tab_FTP_configuration_user_modify_iisRemoteRights_off" qtlid="126368">OFF</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_iisRemoteRights_read" qtlid="198961">READ</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_iisRemoteRights_rw" qtlid="198974">RW</translation>
-   <translation id="hosting_tab_FTP_configuration_user_modify_iisRemoteRights_none" qtlid="30646">Aucun</translation>
+   <translation id="hosting_tab_FTP_configuration_user_modify_iisRemoteRights_none" qtlid="30646">Ninguno</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_step1_webDavRights_label" qtlid="198987">Permisos de WebDAV</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_OFF" qtlid="126368">OFF</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_READ" qtlid="198961">READ</translation>
@@ -1103,7 +1103,7 @@
    <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_off" qtlid="126368">OFF</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_read" qtlid="198961">READ</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_rw" qtlid="198974">RW</translation>
-   <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_none" qtlid="30646">Aucun</translation>
+   <translation id="hosting_tab_FTP_configuration_user_modify_webDavRights_none" qtlid="30646">Ninguno</translation>
 
    <translation id="hosting_tab_FTP_configuration_user_modify_step2_question" qtlid="199130">¿Seguro que desea editar el usuario FTP con los siguientes valores?</translation>
    <translation id="hosting_tab_FTP_configuration_user_modify_step2_user" qtlid="7450">Utilisateur</translation>
@@ -1134,7 +1134,7 @@
    <translation id="hosting_tab_CRON_label_crontab" qtlid="199351">Crontab</translation>
    <translation id="hosting_tab_CRON_email_nic-admin" qtlid="199624">NIC Admin</translation>
    <translation id="hosting_tab_CRON_email_nic-tech" qtlid="199637">NIC Tech</translation>
-   <translation id="hosting_tab_CRON_email_no" qtlid="34788">Non</translation>
+   <translation id="hosting_tab_CRON_email_no" qtlid="34788">No</translation>
    <translation id="hosting_tab_CRON_email_other" qtlid="19963">Autre</translation>
    <translation id="hosting_tab_CRON_email_other_specify" qtlid="199650">Indique...</translation>
    <translation id="hosting_tab_CRON_edit_task" qtlid="37875">Modificar</translation>

--- a/client/app/hosting/translations/Messages_fi_FI.xml
+++ b/client/app/hosting/translations/Messages_fi_FI.xml
@@ -349,7 +349,7 @@ Saat pian sähköpostiviestin, jossa on ohjeet sulkemisprosessiin.</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Luodaan…</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Poistetaan…</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accéder à l'interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Résilier l'abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Êtes-vous sûr de vouloir résilier votre abonnement «Visibilité Pro» pour le compte suivant ?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La suppression de l'abonnement «Visibilité Pro» a bien été prise en compte.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Une erreur est survenue lors de la suppression de votre abonnement «Visibilité Pro».</translation>

--- a/client/app/hosting/translations/Messages_fr_CA.xml
+++ b/client/app/hosting/translations/Messages_fr_CA.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Création en cours</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Suppression en cours</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accéder à l'interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Résilier l'abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Êtes-vous sûr de vouloir résilier votre abonnement «Visibilité Pro» pour le compte suivant ?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La suppression de l'abonnement «Visibilité Pro» a bien été prise en compte.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Une erreur est survenue lors de la suppression de votre abonnement «Visibilité Pro».</translation>

--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Création en cours</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Suppression en cours</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accéder à l'interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="517738">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Êtes-vous sûr de vouloir résilier votre abonnement «Visibilité Pro» pour le compte suivant ?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La suppression de l'abonnement «Visibilité Pro» a bien été prise en compte.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Une erreur est survenue lors de la suppression de votre abonnement «Visibilité Pro».</translation>

--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Création en cours</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Suppression en cours</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accéder à l'interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Résilier l'abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Êtes-vous sûr de vouloir résilier votre abonnement «Visibilité Pro» pour le compte suivant ?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La suppression de l'abonnement «Visibilité Pro» a bien été prise en compte.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Une erreur est survenue lors de la suppression de votre abonnement «Visibilité Pro».</translation>

--- a/client/app/hosting/translations/Messages_it_IT.xml
+++ b/client/app/hosting/translations/Messages_it_IT.xml
@@ -349,7 +349,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Creazione in corso...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Eliminazione in corso...</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accedi all'interfaccia</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancella l'abbonamento</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Vuoi davvero cancellare l'abbonamento "Visibility Pro" per il seguente account?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La cancellazione dell'abbonamento "Visibility Pro" è in fase di elaborazione.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Si è verificato un errore durante la cancellazione dell'abbonamento "Visibility Pro".</translation>

--- a/client/app/hosting/translations/Messages_lt_LT.xml
+++ b/client/app/hosting/translations/Messages_lt_LT.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Kuriama</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Trinama</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Accéder à l'interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Résilier l'abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Êtes-vous sûr de vouloir résilier votre abonnement «Visibilité Pro» pour le compte suivant ?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">La suppression de l'abonnement «Visibilité Pro» a bien été prise en compte.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Une erreur est survenue lors de la suppression de votre abonnement «Visibilité Pro».</translation>

--- a/client/app/hosting/translations/Messages_nl_NL.xml
+++ b/client/app/hosting/translations/Messages_nl_NL.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Wordt aangemaakt...</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Verwijdering wordt uitgevoerd</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Toegang tot de interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Annuleer abonnement</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Weet u zeker dat u uw Visibility Pro account wilt annuleren?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Uw annuleringsverzoek voor dit Visibility Pro account is ontvangen.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Er is een fout opgetreden bij het indienen van uw annuleringsverzoek voor dit account.</translation>

--- a/client/app/hosting/translations/Messages_pl_PL.xml
+++ b/client/app/hosting/translations/Messages_pl_PL.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Tworzenie w trakcie</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Usuwania w trakcie</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Zaloguj się do interfejsu</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Anuluj subskrypcję</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Czy na pewno chcesz zrezygnować z subskrypcji "Pakietu Widoczna firma" dla tego konta?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">Żądanie usunięcia subskrypcji "Pakietu Widoczna firma" zostało wysłane.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Wystąpił błąd podczas usuwania subskrypcji "Pakietu Widoczna firma".</translation>

--- a/client/app/hosting/translations/Messages_pt_PT.xml
+++ b/client/app/hosting/translations/Messages_pt_PT.xml
@@ -348,7 +348,7 @@
    <translation id="hosting_tab_LOCAL_SEO_state_creating" qtlid="146632">Criação em curso</translation>
    <translation id="hosting_tab_LOCAL_SEO_state_deleting" qtlid="146645">Eliminação em curso</translation>
    <translation id="hosting_tab_LOCAL_SEO_access_interface" qtlid="503137">Aceder à interface</translation>
-   <translation id="hosting_tab_LOCAL_SEO_delete" qtlid="503150">Cancelar subscrição</translation>
+   <translation id="hosting_tab_LOCAL_SEO_delete">Supprimer l'abonnement</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_confirm" qtlid="503163">Tem a certeza de que pretende cancelar a sua subscrição de "Visibilidade Pro" para a seguinte conta?</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_success" qtlid="503176">A eliminação da subscrição de "Visibilidade Pro" foi bem-sucedida.</translation>
    <translation id="hosting_tab_LOCAL_SEO_delete_error" qtlid="503189">Ocorreu um erro ao eliminar a subscrição de "Visibilidade Pro".</translation>

--- a/client/app/mailing-list/translations/Messages_es_US.xml
+++ b/client/app/mailing-list/translations/Messages_es_US.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
    <translation id="mailing_list_common_from" qtlid="69077">De</translation>
-   <translation id="mailing_list_common_back" qtlid="4118">Retour</translation>
+   <translation id="mailing_list_common_back" qtlid="4118">Volver</translation>
    <translation id="mailing_list_common_required_fields" qtlid="222111">Los campos marcados con asterisco son obligatorios.</translation>
    <translation id="mailing_list_common_continue_question" qtlid="351909">¿Desea continuar?</translation>
    <translation id="mailing_list_common_invalid_email" qtlid="212036">El correo electrónico no es válido.</translation>
@@ -23,7 +23,7 @@
 
    <translation id="mailing_list_tab_table_header_list_name" qtlid="3818">Nombre</translation>
    <translation id="mailing_list_tab_table_header_list_owner_email" qtlid="30634">Propietario</translation>
-   <translation id="mailing_list_tab_table_header_list_language" qtlid="30598">Langue</translation>
+   <translation id="mailing_list_tab_table_header_list_language" qtlid="30598">Idioma</translation>
    <translation id="mailing_list_tab_table_header_list_reply_to" qtlid="219459">Respuesta a</translation>
    <translation id="mailing_list_tab_table_header_list_nb_subscribers" qtlid="219472">Nº de inscritos</translation>
    <translation id="mailing_list_tab_table_header_list_moderators" qtlid="54725">Modérateurs</translation>

--- a/client/app/private-database/translations/Messages_es_US.xml
+++ b/client/app/private-database/translations/Messages_es_US.xml
@@ -57,7 +57,7 @@
    <translation id="privateDatabase_dashboard_see_certificate" qtlid="448353">Ver el certificado</translation>
    <translation id="privateDatabase_dashboard_service_hosting_more" qtlid="325924">Ver la lista</translation>
    <translation id="privateDatabase_dashboard_service_hosting_linked" qtlid="444456">Plan de alojamiento asociado</translation>
-   <translation id="privateDatabase_dashboard_service_hosting_linked_none" qtlid="30646">Aucun</translation>
+   <translation id="privateDatabase_dashboard_service_hosting_linked_none" qtlid="30646">Ninguno</translation>
 
    <translation id="privateDatabase_dashboard_connections_title" qtlid="250927">Datos de conexión</translation>
    <translation id="privateDatabase_dashboard_ftp_informations_legacy" qtlid="50410">FTP</translation>
@@ -66,7 +66,7 @@
    <translation id="privateDatabase_dashboard_admin_informations" qtlid="264001">Administración de la base de datos</translation>
    <translation id="privateDatabase_dashboard_admin_informations_users" qtlid="264014">Diríjase a la pestaña de usuarios y derechos</translation>
 
-   <translation id="privateDatabase_dashboard_name_validate" qtlid="26047">Valider</translation>
+   <translation id="privateDatabase_dashboard_name_validate" qtlid="26047">Aceptar</translation>
    <translation id="privateDatabase_dashboard_name_cancel" qtlid="37863">Cancelar</translation>
 
    <translation id="privateDatabase_tab_USER" qtlid="215689">Usuarios y derechos</translation>
@@ -87,7 +87,7 @@
    <translation id="privateDatabase_configuration_alert" qtlid="482212">Cualquier modificación requiere el reinicio del servidor.</translation>
    <translation id="privateDatabase_configuration_edit_btn" qtlid="185452">Editar</translation>
    <translation id="privateDatabase_configuration_cancel_btn" qtlid="37863">Cancelar</translation>
-   <translation id="privateDatabase_configuration_confirm_btn" qtlid="41326">Appliquer</translation>
+   <translation id="privateDatabase_configuration_confirm_btn" qtlid="41326">Aplicar</translation>
    <translation id="privateDatabase_configuration_reboot" qtlid="263520">Modificando configuración... eu servidor se va a reiniciar.</translation>
    <translation id="privateDatabase_configuration_error_put" qtlid="263533">Se ha producido un error al modificar la configuración.</translation>
    <translation id="privateDatabase_configuration_error" qtlid="233047">Se ha producido un error al recuperar la información.</translation>
@@ -125,12 +125,12 @@
 
    <translation id="privateDatabase_tabs_refresh_data" qtlid="413284">Recargar los datos</translation>
 
-   <translation id="privateDatabase_tabs_user_no_grant" qtlid="30646">Aucun</translation>
+   <translation id="privateDatabase_tabs_user_no_grant" qtlid="30646">Ninguno</translation>
    <translation id="privateDatabase_tabs_no_user" qtlid="215741">Ningún usuario</translation>
    <translation id="privateDatabase_tabs_no_user_error" qtlid="232995">No se pueden mostrar los usuarios.</translation>
    <translation id="privateDatabase_tabs_user_grant_admin" qtlid="43948">Administrador</translation>
    <translation id="privateDatabase_tabs_user_grant_admin_tooltip" qtlid="342715">Autorización de solicitudes de tipo: Select/Insert/Update/Delete/Create/Alter/Drop</translation>
-   <translation id="privateDatabase_tabs_user_grant_none" qtlid="30646">Aucun</translation>
+   <translation id="privateDatabase_tabs_user_grant_none" qtlid="30646">Ninguno</translation>
    <translation id="privateDatabase_tabs_user_grant_none_tooltip" qtlid="342728">No hay licencias en esta DB</translation>
    <translation id="privateDatabase_tabs_user_grant_ro" qtlid="6958">Lecture</translation>
    <translation id="privateDatabase_tabs_user_grant_ro_tooltip" qtlid="342741">Autorización de solicitudes de tipo: Select</translation>
@@ -313,7 +313,7 @@
    <translation id="privateDatabase_add_bdd_new_user" qtlid="7810">Créer un utilisateur</translation>
    <translation id="privateDatabase_add_bdd_new_user_login" qtlid="56045">Nombre de usuario</translation>
    <translation id="privateDatabase_add_bdd_new_user_grant" qtlid="65286">Droits</translation>
-   <translation id="privateDatabase_add_bdd_new_user_grant_none" qtlid="30646">Aucun</translation>
+   <translation id="privateDatabase_add_bdd_new_user_grant_none" qtlid="30646">Ninguno</translation>
    <translation id="privateDatabase_add_bdd_new_user_grant_admin" qtlid="43948">Administrador</translation>
    <translation id="privateDatabase_add_bdd_new_user_grant_ro" qtlid="17333">Lecture seule</translation>
    <translation id="privateDatabase_add_bdd_new_user_grant_rw" qtlid="300526">Lectura-escritura</translation>
@@ -329,7 +329,7 @@
    <translation id="privateDatabase_restore_bdd_application" qtlid="404707">Primeramente debe volver a crearla en la pestaña de gestión de sus bases de datos.</translation>
    <translation id="privateDatabase_restore_bdd_close" qtlid="4670">Cerrar</translation>
    <translation id="privateDatabase_restore_bdd_confirm" qtlid="272290">¿Desea restaurar el backup del <strong>{0}</strong> de la base de datos <strong>{1}</strong>?</translation>
-   <translation id="privateDatabase_restore_bdd_continue" qtlid="4070">Continuer</translation>
+   <translation id="privateDatabase_restore_bdd_continue" qtlid="4070">Continuar</translation>
    <translation id="privateDatabase_restore_bdd_error" qtlid="404720">Se ha producido un error al cargar los datos.</translation>
    <translation id="privateDatabase_restore_bdd_fail" qtlid="413362">Se ha producido un error al restaurar el backup. Es posible que la base de datos no exista o que ningún usuario tenga suficientes permisos.</translation>
    <translation id="privateDatabase_restore_bdd_go_list" qtlid="404746">Gestionar mis bases de datos</translation>
@@ -362,7 +362,7 @@
    <translation id="privateDatabase_tabs_users_database_no_users" qtlid="329538">No hay usuarios para esta base de datos</translation>
    <translation id="privateDatabase_tabs_users_database_name" qtlid="329551">Usuarios de la base de datos</translation>
    <translation id="privateDatabase_tabs_users_database_grant_admin" qtlid="43948">Administrador</translation>
-   <translation id="privateDatabase_tabs_users_database_grant_none" qtlid="30646">Aucun</translation>
+   <translation id="privateDatabase_tabs_users_database_grant_none" qtlid="30646">Ninguno</translation>
    <translation id="privateDatabase_tabs_users_database_grant_ro" qtlid="6958">Lecture</translation>
    <translation id="privateDatabase_tabs_users_database_grant_rw" qtlid="215754">Lectura y escritura</translation>
 
@@ -405,7 +405,7 @@
    <translation id="privateDatabase_order_RAM_price_HT" qtlid="146177">Precio:</translation>
    <translation id="privateDatabase_order_RAM_price_TTC" qtlid="146190">Precio:</translation>
    <translation id="privateDatabase_expiration_date" qtlid="33010">Date d'expiration</translation>
-   <translation id="privateDatabase_renew_date" qtlid="98300">Renouvellement automatique</translation>
+   <translation id="privateDatabase_renew_date" qtlid="98300">Renovación automática</translation>
    <translation id="privateDatabase_gui" qtlid="103642">Interface utilisateur</translation>
    <translation id="privateDatabase_tabs_bdd_no" qtlid="220746">No hay bases de datos</translation>
 
@@ -550,7 +550,7 @@
 <!-- RELOAD -->
    <translation id="privateDatabase_tabs_whitelist_list_reload_description" qtlid="218081">Recargar la tabla</translation>
 <!-- POPOVER -->
-   <translation id="privateDatabase_tabs_whitelist_list_popover_description" qtlid="23395">Options</translation>
+   <translation id="privateDatabase_tabs_whitelist_list_popover_description" qtlid="23395">Opciones</translation>
    <translation id="privateDatabase_tabs_whitelist_list_popover_edit" qtlid="404993">Editar la whitelist</translation>
    <translation id="privateDatabase_tabs_whitelist_list_popover_delete" qtlid="405006">Eliminar la whitelist</translation>
 <!-- LIST -->

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@bower_components/ng-ckeditor": "esvit/ng-ckeditor#^0.2.1",
     "@bower_components/ng-file-upload-shim": "danialfarid/angular-file-upload-shim-bower#^12.0.4",
     "@bower_components/randexp": "fent/randexp.js#^0.4.0",
-    "@ovh-ux/ng-payment-method": "^1.0.0-alpha.1",
+    "@ovh-ux/ng-ovh-payment-method": "^1.0.0",
     "@ovh-ux/ovh-utils-angular": "^13.0.4",
     "@ovh-ux/translate-async-loader": "^1.0.7",
     "@ovh-ux/web-universe-components": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.1.1",
     "ovh-module-exchange": "^9.2.3",
-    "ovh-module-office": "^7.0.4",
+    "ovh-module-office": "^7.0.5",
     "ovh-module-sharepoint": "^7.0.8",
     "ovh-ui-angular": "^2.23.0",
     "ovh-ui-kit": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.1.1",
-    "ovh-module-exchange": "^9.2.2",
+    "ovh-module-exchange": "^9.2.3",
     "ovh-module-office": "^7.0.4",
     "ovh-module-sharepoint": "^7.0.8",
     "ovh-ui-angular": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/ng-ovh-payment-method": "^1.0.0",
     "@ovh-ux/ovh-utils-angular": "^13.0.4",
     "@ovh-ux/translate-async-loader": "^1.0.7",
-    "@ovh-ux/web-universe-components": "^1.0.0",
+    "@ovh-ux/web-universe-components": "^1.2.0",
     "@uirouter/angularjs": "^1.0.0",
     "URIjs": "^1.14.0",
     "angular": "~1.6.10",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@bower_components/ng-ckeditor": "esvit/ng-ckeditor#^0.2.1",
     "@bower_components/ng-file-upload-shim": "danialfarid/angular-file-upload-shim-bower#^12.0.4",
     "@bower_components/randexp": "fent/randexp.js#^0.4.0",
+    "@ovh-ux/ng-payment-method": "^1.0.0-alpha.1",
     "@ovh-ux/ovh-utils-angular": "^13.0.4",
     "@ovh-ux/translate-async-loader": "^1.0.7",
     "@ovh-ux/web-universe-components": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ovh-angular-tail-logs": "^1.1.1",
     "ovh-angular-toaster": "ovh-ux/ovh-angular-toaster#^0.8.0",
     "ovh-angular-user-pref": "ovh-ux/ovh-angular-user-pref#^0.3.1",
-    "ovh-api-services": "^3.24.0",
+    "ovh-api-services": "^3.28.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,10 +981,10 @@
     request "^2.88.0"
     webpack-dev-server "^3.1.9"
 
-"@ovh-ux/ng-payment-method@^1.0.0-alpha.1":
-  version "1.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-payment-method/-/ng-payment-method-1.0.0-alpha.1.tgz#b314dc43911b51f5457d71340f12d785436b3d5c"
-  integrity sha512-9+G5dZ6LTTjqGi/Dv5XgAawCTmULPC1v+YwIOjb1vYd/yBFqY3mHFrjLtX/KMQBtYMQe9mdNJAx8U9nmUqo8Fw==
+"@ovh-ux/ng-ovh-payment-method@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-payment-method/-/ng-ovh-payment-method-1.0.0.tgz#78fcccf0e8c604cc00011cf98ad38c0156bf9ea5"
+  integrity sha512-Cn7/7KQhbLik9/9Iye/Z4P618TEkDt9sgriOkzSmNwEamgbcLINJDhgcdQe3wypPiT1K+IwnULos5DjB9U/LMQ==
 
 "@ovh-ux/ovh-utils-angular@^13.0.4":
   version "13.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7642,10 +7642,10 @@ ovh-angular-user-pref@ovh-ux/ovh-angular-user-pref#^0.3.1:
   version "0.3.1"
   resolved "https://codeload.github.com/ovh-ux/ovh-angular-user-pref/tar.gz/71d0b3c0606a2e2052505bda2a8e2ff06b0156e1"
 
-ovh-api-services@^3.24.0:
-  version "3.24.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.24.0.tgz#a0ed96b70f23dcdc26b1bfaa26890cc3939d4270"
-  integrity sha512-jo2Jb73Vpy0rKz6Z/qq5b1GAbfu3ayVRKg7yVJmdRnahVYx7QQ5ne7SJQq4xersQh9CAC5TQNr79w0I1p1VLBw==
+ovh-api-services@^3.28.0:
+  version "3.28.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-3.28.0.tgz#b2869540d6e99ba883e9916cf73ed3395a4c8293"
+  integrity sha512-30HT2bGWB3jh+cw+KYHLCvUnBLjQgZ8x6Wu+Q8J8U846/GUHSKeYSBk4TWEEcJC06HJkXVrZMYzwq/ITr+UIWA==
   dependencies:
     lodash "^3.10.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,6 +1295,14 @@ ajv-keywords@^3.0.0, ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
+ajv@^4.9.1:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -4791,6 +4799,11 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
 
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -5916,6 +5929,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -7656,10 +7676,10 @@ ovh-module-exchange@^9.2.3:
     filesize "^3.6.1"
     lodash "~3.9.3"
 
-ovh-module-office@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/ovh-module-office/-/ovh-module-office-7.0.4.tgz#d591c818a0a1f68854681b23684ce6afaa0dbc92"
-  integrity sha512-b1zLI5j38rEfE6ajr8cwPCQK7VVKL/cEI7hZSRHejkrZrIg8KngS+XyMgzVfd89fWKY5EZ08HAX8q5Kwd3PmAQ==
+ovh-module-office@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ovh-module-office/-/ovh-module-office-7.0.5.tgz#d0a6ab80aec598444ba6926be5df49f26accc927"
+  integrity sha512-+umi0h5FrVMszAOxk/wYIvURXDdKCZJMbj5Uin0Y8EjaHqFYRBaDz5nxbtq1TW/ocU5aXbVvz1yasGPMjaIWsA==
   dependencies:
     angular "~1.6.10"
     jsurl "^0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,14 +1295,6 @@ ajv-keywords@^3.0.0, ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -4799,11 +4791,6 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -4813,6 +4800,9 @@ har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
+  dependencies:
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
 
 har-validator@~5.1.0:
   version "5.1.0"
@@ -5926,13 +5916,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
-
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -7665,10 +7648,10 @@ ovh-module-emailpro@^7.1.1:
     punycode "^1.2.4"
     validator "^4.0.0"
 
-ovh-module-exchange@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.2.2.tgz#40a461ef9307163f2e021f187b3a208e36745162"
-  integrity sha512-8RosRDpqpCBAu6vKuSfVWFnX2EC8GCa7frZ/iTMhZ/LXwpGoxcEKs5r/VeZtEW4DvV522GbUfD9IE2ZkmoETyw==
+ovh-module-exchange@^9.2.3:
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.2.3.tgz#c1481a0d52eb3642c544b94bde740be2548ba58a"
+  integrity sha512-vHcxg0JWtYdds+/q7xd6niWQyxciZlXvNmg+0gtH3a2nNfK77wpI19M+VaeBWNHSzS49+/dXvR8NHFeAQw+ZJQ==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,10 +996,10 @@
   resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"
   integrity sha512-8yEhPeRTSxtEO9ODXRYZw6pzRQiV5ULCTi8mIzt39m/b9N2TcIF4ILTPsaa8xpE4npHKa/iYgL9z0HJUFi2LGQ==
 
-"@ovh-ux/web-universe-components@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/web-universe-components/-/web-universe-components-1.0.0.tgz#976d82c8f424248cefe11331a2aeb7f9ca1742c0"
-  integrity sha512-SBh3K7x4NpIroRh3hbfn8AIu9UTZjGZ9ADoFfxpwxHq8lCqEtvjmXh/zmlaSZnaVPr8O9RrGWWHA/KO8iMq2Xg==
+"@ovh-ux/web-universe-components@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/web-universe-components/-/web-universe-components-1.2.0.tgz#012d6b78ef37870fece5b80020b83a9655ecc230"
+  integrity sha512-2dFIJqm99HRzZY07UViNEMRfzyiRKCpq71vgY/HKoYfGCYP3UVngrmh0Z91an3kgKYA0oTumKoCCSP7vXojR8g==
   dependencies:
     bootstrap "^3.3.7"
     ovh-ui-kit "^2.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@
     request "^2.88.0"
     webpack-dev-server "^3.1.9"
 
+"@ovh-ux/ng-payment-method@^1.0.0-alpha.1":
+  version "1.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-payment-method/-/ng-payment-method-1.0.0-alpha.1.tgz#b314dc43911b51f5457d71340f12d785436b3d5c"
+  integrity sha512-9+G5dZ6LTTjqGi/Dv5XgAawCTmULPC1v+YwIOjb1vYd/yBFqY3mHFrjLtX/KMQBtYMQe9mdNJAx8U9nmUqo8Fw==
+
 "@ovh-ux/ovh-utils-angular@^13.0.4":
   version "13.0.4"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ovh-utils-angular/-/ovh-utils-angular-13.0.4.tgz#3acf47e4723ab7292f06bc38bf5b4085e66e7916"


### PR DESCRIPTION
## 📦 Prepare v13.12.0

### Description of the Change

#### 🐛 Bug Fixes

MBE-159 — fix(welcome): change message for FR subsidiary
MBP-228 — fix(hosting): rename delete subscription button label

#### 🚀 Features

MANAGER-2002 — feat(domain): display autorenew invite when needed
MANAGER-2002 — feat(hosting): display autorenew invite

#### ⬆️ Module Exchange `v9.2.3`

MBE-210 — fix(header.renew): fix renewal frequency translation
MBP-252 — fix(exchange.disclaimer): disable oui-action-menu

#### ⬆️ Module Office `v7.0.5`

MBP-49 — fix(license.user): edit user while update in progress

#### ⬆️ Web Universe Components `v1.2.0`

MANAGER-2002 — feat(autorenew-invite): init component
MANAGER-2003 — feat(expiration): distinguish expiration from resiliation