### PR TITLE
fix(domains-zone-cnme): validation for cname records

### DIFF
--- a/client/app/domain/zone/record/header.html
+++ b/client/app/domain/zone/record/header.html
@@ -4,8 +4,8 @@
 </p>
 
 <div class="form-group" data-ng-class="{
-    'has-error': ctrl.zoneRecordForm.subDomainToDisplay.$dirty && ctrl.zoneRecordForm.subDomainToDisplay.$invalid,
-    'has-warning': ctrl.existingSubDomain && ctrl.existingSubDomain.length > 0 }">
+    'has-error': ctrl.zoneRecordForm.subDomainToDisplay.$dirty && ctrl.zoneRecordForm.subDomainToDisplay.$invalid && !ctrl.loading.checkSubDomain,
+    'has-warning': ctrl.existingSubDomainsWarning }">
     <label class="control-label col-md-3" for="subDomainToDisplay"
            data-translate="domain_configuration_dns_entry_add_subdomain"
            data-ng-class="{ 'required': ctrl.model.fieldType === 'NS' }"></label>
@@ -21,7 +21,7 @@
         </div>
         <small class="help-block"
                data-translate="domain_configuration_dns_entry_add_subdomain_already_configured"
-               data-ng-if="ctrl.existingSubDomain && ctrl.existingSubDomain.length > 0"></small>
+               data-ng-if="ctrl.existingSubDomainsWarning || ctrl.existingSubDomainsError"></small>
     </div>
 </div>
 


### PR DESCRIPTION
Close MBE-189

### Requirements

A CNAME record is not allowed to coexist with any other data. In other words, if suzy.podunk.xx is an alias for sue.podunk.xx, you can't also have an MX record for suzy.podunk.xx, or an A record, or even a TXT record.

## CNAME Record validation


### Description of the Change

The validation for records have been added so that they are not created by the same sub-domain as an existing CNAME record or vice-versa.