### PR TITLE
fix(domains-zone-edit): validation for cname record update

### DIFF
--- a/client/app/domain/domain.service.js
+++ b/client/app/domain/domain.service.js
@@ -584,7 +584,8 @@ angular.module('services').service(
           ).then((results) => {
             const existingSubDomain = _.filter(
               results.paginatedZone.records.results,
-              zone => zone.subDomain.toLowerCase() === subDomain.toLowerCase(),
+              zone => zone.subDomain.toLowerCase() === subDomain.toLowerCase()
+                  && zone.id !== entry.excludeId,
             );
             return !existingSubDomain.length;
           });


### PR DESCRIPTION
Close MBE-271

### Requirements

When a CNAME record is being edited, it should not consider itself while checking for duplicate records.

## CNAME record update fix


### Description of the Change

The issue is fixed by excluding the cname record while checking for duplicates