### PR TITLE
fix(domains-zone-edit): cname conflict text

### DIFF
--- a/client/app/domain/domain.service.js
+++ b/client/app/domain/domain.service.js
@@ -513,11 +513,11 @@ angular.module('services').service(
      * @param {string} subDomain
      * @param {string} excludeId
      */
-    checkIfRecordHaveNoBrothers(serviceName, fieldType, subDomain, excludeId) {
+    getExistingSubdomains(serviceName, fieldType, subDomain, excludeId) {
       return this.getRecordsIds(serviceName, {
         fieldType,
         subDomain: subDomain || '',
-      }).then(recordsIds => _.isEmpty(_.without(recordsIds, excludeId)));
+      }).then(recordsIds => _.without(recordsIds, excludeId));
     }
 
     /**
@@ -587,17 +587,20 @@ angular.module('services').service(
               zone => zone.subDomain.toLowerCase() === subDomain.toLowerCase()
                   && zone.id !== entry.excludeId,
             );
-            return !existingSubDomain.length;
+            return {
+              recordCanBeAdded: !existingSubDomain.length,
+              conflictingRecords: existingSubDomain,
+            };
           });
         // Rule for Other Record types:
         // Can not have a CNAME of this subDomain
         default:
-          return this.checkIfRecordHaveNoBrothers(
+          return this.getExistingSubdomains(
             serviceName,
             'CNAME',
             subDomain,
             entry.excludeId,
-          ).then(haveNoBrothers => haveNoBrothers);
+          ).then(recordIds => ({ recordCanBeAdded: _.isEmpty(recordIds) }));
       }
     }
 

--- a/client/app/domain/translations/Messages_fr_FR.xml
+++ b/client/app/domain/translations/Messages_fr_FR.xml
@@ -519,7 +519,7 @@
    <translation id="domain_configuration_dns_entry_add_step3_alert" qtlid="195048">La modification sera immédiate dans la zone DNS, mais veuillez prendre en compte le temps de propagation (maximum 24h).</translation>
 
    <translation id="domain_configuration_dns_entry_add_step3_check_warning1" qtlid="215065">Attention, un ou plusieurs conflits peuvent survenir :</translation>
-   <translation id="domain_configuration_dns_entry_add_step3_check_warning2" qtlid="519831">Le sous-domaine est déjà utilisé par un autre enregistrement. Un enregistrement CNAME n'est pas autorisé à coexister avec d'autres champs sur le même sous-domaine.</translation>
+   <translation id="domain_configuration_dns_entry_add_step3_check_warning2">Le sous-domaine utilise déjà un enregistrement DNS. Vous ne pouvez pas enregistrer de champ CNAME en raison d'une incompatibilité. Supprimez les enregistrements existants pour ce sous-domaine, afin de pouvoir en ajouter un, de type CNAME.</translation>
    <translation id="domain_configuration_dns_entry_add_step3_check_warning3" qtlid="519844">Le sous-domaine est déjà utilisé par un enregistrement CNAME. Un enregistrement CNAME n'est pas autorisé à coexister avec d'autres champs sur le même sous-domaine.</translation>
 
    <translation id="domain_configuration_dns_entry_add_success" qtlid="129243">L'entrée a été ajoutée à la zone DNS.</translation>

--- a/client/app/domain/zone/record/domain-zone-record.controller.js
+++ b/client/app/domain/zone/record/domain-zone-record.controller.js
@@ -93,8 +93,14 @@ angular.module('App').controller(
         subDomain: punycode.toASCII(this.model.subDomainToDisplay || ''),
         target: this.model.target.value,
       })
-        .then((isOk) => {
-          this.recordConflicts = isOk;
+        .then(({ recordCanBeAdded, conflictingRecords }) => {
+          this.recordConflicts = recordCanBeAdded;
+          this.conflictingRecords = conflictingRecords;
+          _.each(this.conflictingRecords, (record) => {
+            _.set(record, 'domainToDisplay', `${(record.subDomainToDisplay
+              ? `${record.subDomainToDisplay}.`
+              : '') + record.zoneToDisplay}.`);
+          });
         })
         .finally(() => {
           this.loading.resume = false;

--- a/client/app/domain/zone/record/resume.html
+++ b/client/app/domain/zone/record/resume.html
@@ -19,14 +19,18 @@
         <dd class="word-break" data-ng-bind="ctrl.model.target.value"></dd>
     </dl>
 
-    <div class="alert alert-danger mt-4" role="alert"
-         data-ng-if="!ctrl.recordConflicts">
-        <div data-ng-if="ctrl.model.fieldType === 'CNAME'"
-             data-translate="domain_configuration_dns_entry_add_step3_check_warning2">
-        </div>
-        <div data-ng-if="ctrl.model.fieldType !== 'CNAME'"
-             data-translate="domain_configuration_dns_entry_add_step3_check_warning3">
-        </div>
+    <div data-ng-if="!ctrl.recordConflicts">
+        <oui-message type="error">
+            <span data-ng-if="ctrl.model.fieldType === 'CNAME'"
+                  data-translate="domain_configuration_dns_entry_add_step3_check_warning2"></span>
+            <span data-ng-if="ctrl.model.fieldType !== 'CNAME'"
+                  data-translate="domain_configuration_dns_entry_add_step3_check_warning3"></span>
+        </oui-message>
+        <oui-datagrid data-ng-if="ctrl.model.fieldType === 'CNAME'" data-rows="ctrl.conflictingRecords" data-page-size="5">
+            <oui-column data-title="'domain_tab_ZONE_table_headers_field'|translate" data-property="domainToDisplay" data-sortable="asc" data-type="string"></oui-column>
+            <oui-column data-title="'domain_tab_ZONE_table_headers_type'|translate" data-property="fieldType" data-sortable data-type="string"></oui-column>
+            <oui-column data-title="'domain_tab_ZONE_table_headers_target'|translate" data-property="targetToDisplay" data-sortable data-type="string"></oui-column>
+        </oui-datagrid>
     </div>
 
     <div class="alert alert-warning mt-4" role="alert"


### PR DESCRIPTION
Close MBE-277

### Requirements

While creating a cname record, if there are conflicting records for the same sub-domain, the user should be advised to delete those records (with the list of records)

## Cname record conflict text change


### Description of the Change

The error text has been modified, also listing the conflicting records.