### PR TITLE
fix(deps): upgrade ovh-module-sharepoint to v7.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ovh-module-emailpro": "^7.1.3",
     "ovh-module-exchange": "^9.3.1",
     "ovh-module-office": "^7.0.6",
-    "ovh-module-sharepoint": "^7.1.1",
+    "ovh-module-sharepoint": "^7.1.2",
     "ovh-ui-angular": "^2.24.1",
     "ovh-ui-kit": "^2.24.1",
     "ovh-ui-kit-bs": "~1.3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,10 +7695,10 @@ ovh-module-office@^7.0.6:
     lodash "~3.9.3"
     moment "^2.16.0"
 
-ovh-module-sharepoint@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/ovh-module-sharepoint/-/ovh-module-sharepoint-7.1.1.tgz#5958de42550aa0c362e2f41505c3922af21319a8"
-  integrity sha512-btwkdlHBNzR84B9S9cW+c9Gm4tAX3bpY9jzCFaJbRpeX4LS4tc33+1R6SzBvhJmOwhfvXUBEur8vEYmB48xcUg==
+ovh-module-sharepoint@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/ovh-module-sharepoint/-/ovh-module-sharepoint-7.1.2.tgz#bae4558440cfc85a1469ade4ff06df7a2731b778"
+  integrity sha512-0CUAW17+Z3oInobIHbFQoVTvovSF8L1lFBAYu2+Wms5AMWPiiqMljTe/Z5fbHS2PXNEjlWFo4VOQbYLALePpcw==
   dependencies:
     angular "~1.6.10"
     filesize "^3.5.10"


### PR DESCRIPTION
# Upgrade `ovh-module-sharepoint`

### 🐛 Bug Fix

MBE-296 - fix(order): allow subs to order classic sharepoint accounts

uses: yarn upgrade-interactive --latest
- ovh-module-sharepoint@7.1.2
