### PR TITLE
fix(web-hosting): tracking pages multiple times

### DIFF
--- a/client/app/domain/domain-tabs.controller.js
+++ b/client/app/domain/domain-tabs.controller.js
@@ -123,21 +123,31 @@ angular.module('App').controller(
               });
           }
 
-          this.setSelectedTab(angular.uppercase(this.$stateParams.tab));
+          this.setSelectedTab(angular.uppercase(this.$stateParams.tab), true);
         });
     }
 
-    setSelectedTab(tab) {
+    setSelectedTab(tab, trackPageOnly) {
       if (_.includes(this.tabs, tab)) {
         this.selectedTab = tab;
       } else {
         this.selectedTab = this.defaultTab;
       }
 
-      this.atInternet.trackClick({
-        name: `web::domain::product-${this.selectedTab}`,
-        type: 'action',
-      });
+      if (trackPageOnly) {
+        this.atInternet.trackPage({
+          name: `web::domain::product-${this.selectedTab}`,
+        });
+      } else {
+        this.atInternet.trackClick({
+          name: `web::domain::product-${this.selectedTab}`,
+          type: 'action',
+        });
+        this.atInternet.trackPage({
+          name: `web::domain::product-${this.selectedTab}`,
+          type: 'action',
+        });
+      }
 
       this.$location.search('tab', this.selectedTab);
     }

--- a/client/app/domain/domain.routes.js
+++ b/client/app/domain/domain.routes.js
@@ -13,6 +13,9 @@ angular.module('App').config(($stateProvider) => {
     params: {
       tab: null,
     },
+    atInternet: {
+      ignore: true, // this tell AtInternet to not track this state
+    },
     resolve: {
       currentSection: () => 'domain',
       navigationInformations: [


### PR DESCRIPTION
## Remove multiple tracking for page with tab in domain


### Description of the Change

don't track pages which have tabs multiple time
add page tracking in controller and disable in route

### Benefits

Helps track page and click on tabs

### Possible Drawbacks

None

### Applicable Issues

resolves MBE-278
