### PR TITLE
fix(hosting-multisite): order and regenerate buttons visibility

### DIFF
--- a/client/app/hosting/hosting.constant.js
+++ b/client/app/hosting/hosting.constant.js
@@ -5,4 +5,7 @@ angular.module('App').constant('HOSTING', {
       value: 15,
     },
   },
+  offers: {
+    START_10_M: 'START_10_M',
+  },
 });

--- a/client/app/hosting/multisite/MULTISITE.html
+++ b/client/app/hosting/multisite/MULTISITE.html
@@ -174,16 +174,25 @@
         </div>
         <aside class="col-md-3 mt-5 mt-lg-0">
             <div class="mb-5">
-                <button type="button" class="btn btn-block btn-default text-wrap" title="{{ 'hosting_tab_DOMAINS_configuration_attachDomain_title_button' | translate }}"
+                <button type="button" class="oui-button oui-button_full-width oui-button_secondary" title="{{ 'hosting_tab_DOMAINS_configuration_attachDomain_title_button' | translate }}"
                         data-translate="hosting_tab_DOMAINS_configuration_attachDomain_title_button"
                         data-ng-click="setAction('multisite/add/hosting-multisite-add', {domains: domains})">
                 </button>
                 <button
                     type="button"
-                    class="btn btn-block btn-default text-wrap"
-                    data-ng-bind="sslCertificate ? ('hosting_ssl_regenerate_title_button' | translate) : ('hosting_dashboard_service_order_ssl' | translate)"
-                    data-ng-click="setAction(sslCertificate ? 'ssl/regenerate/hosting-ssl-regenerate' : 'ssl/order/hosting-order-ssl')"
-                    data-ng-if="!hosting.hasHostedSsl && !(sslCertificate.status === 'deleting' || sslCertificate.status === 'regenerating' || sslCertificate.status === 'creating')">
+                    class="oui-button oui-button_full-width oui-button_secondary mt-2"
+                    data-translate="hosting_dashboard_service_order_ssl"
+                    data-ng-click="setAction('ssl/order/hosting-order-ssl')"
+                    data-ng-if="!sslCertificate || !isSSLCertificateOperationInProgress(sslCertificate)">
+                </button>
+                <button
+                    type="button"
+                    class="oui-button oui-button_full-width oui-button_secondary mt-2"
+                    data-translate="hosting_ssl_regenerate_title_button"
+                    data-ng-click="setAction('ssl/regenerate/hosting-ssl-regenerate')"
+                    data-ng-if="sslCertificate
+                        && isLetsEncryptCertificate(sslCertificate)
+                        && !isSSLCertificateOperationInProgress(sslCertificate)">
                 </button>
             </div>
         </aside>

--- a/client/app/hosting/multisite/hosting-multisite.controller.js
+++ b/client/app/hosting/multisite/hosting-multisite.controller.js
@@ -9,13 +9,15 @@ angular
       $location,
       $translate,
       Hosting,
+      HOSTING,
       HostingDomain,
       hostingSSLCertificate,
-      $timeout,
+      hostingSSLCertificateType,
       Alerter,
     ) => {
       $scope.domains = null;
       $scope.sslLinked = [];
+      $scope.HOSTING = HOSTING;
       $scope.showGuidesStatus = false;
       $scope.search = {
         text: null,
@@ -25,7 +27,7 @@ angular
         domains: false,
         init: true,
       };
-
+      $scope.certificateTypes = hostingSSLCertificateType.constructor.getCertificateTypes();
       $scope.loadDomains = function loadDomains(count, offset) {
         $scope.loading.domains = true;
 
@@ -138,6 +140,14 @@ angular
         $scope.setAction('multisite/delete/hosting-multisite-delete', domain);
       };
 
+      $scope.isLetsEncryptCertificate = sslCertificate => (
+        sslCertificate.provider === $scope.certificateTypes.LETS_ENCRYPT.providerName
+      );
+
+      $scope.isSSLCertificateOperationInProgress = sslCertificate => (sslCertificate.status === 'deleting'
+        || sslCertificate.status === 'regenerating'
+        || sslCertificate.status === 'creating');
+
       $scope.modifyDomain = (domain) => {
         $scope.setAction('multisite/update/hosting-multisite-update', domain);
       };
@@ -240,6 +250,13 @@ angular
           _.get(err, 'data', err),
           $scope.alerts.main,
         );
+      });
+
+      $scope.$on('hosting.ssl.reload', () => {
+        hostingSSLCertificate.retrievingCertificate($stateParams.productId)
+          .then((certificate) => {
+            $scope.sslCertificate = certificate;
+          });
       });
 
       function startPolling() {

--- a/client/app/hosting/ssl/order/hosting-order-ssl.html
+++ b/client/app/hosting/ssl/order/hosting-order-ssl.html
@@ -59,7 +59,7 @@
                 <div class="alert alert-info"
                      role="alert"
                      data-ng-bind-html="'hosting_ssl_limit_characters_info_warning' | translate: { t0: $ctrl.Validator.MAX_DOMAIN_LENGTH }"
-                     data-ng-if="!$ctrl.step1.canOrderLetEncryptCertificate"></div>
+                     data-ng-if="!$ctrl.step1.canOrderLetEncryptCertificate && $ctrl.step1.sslCharLimitExceeded"></div>
                 <div class="alert alert-warning"
                      role="alert"
                      data-ng-if="$ctrl.step1.cannotOrderPaidCertificateErrorMessage !== undefined"


### PR DESCRIPTION
Close MBP-98

### Requirements

* The button for ordering a new SSL should be displayed all the time, even if an SSL certificate already exists, because the user can upsell by ordering a better (or smaller) SSL certificate.
* The regenerate button must be displayed, when the account has an SSL certificate with the provider 'Letsencrypt' because regeneration is only available for LetsEncrypt.

## Order and Regenerate Buttons visibility

### Description of the Change

The above changes have been done. In addition, the LetsEncrypt button has been removed from the Order pop-up, when the hosting service already has a SSL certificate with provider 'LetsEncrypt'.