### PR TITLE
fix(domain-zone): prevent multiple records getting added

### DIFF
--- a/client/app/domain/zone/record/domain-zone-record.controller.js
+++ b/client/app/domain/zone/record/domain-zone-record.controller.js
@@ -665,6 +665,7 @@ angular.module('App').controller(
 
     // Add DNS ----------------------------------------------------------------
     addDnsEntry() {
+      this.loading.resume = true;
       return this.Domain.addDnsEntry(this.domain.name, {
         fieldType: this.model.fieldType,
         subDomainToDisplay: this.model.subDomainToDisplay,
@@ -691,6 +692,7 @@ angular.module('App').controller(
 
     // Update DNS -------------------------------------------------------------
     editDnsEntry() {
+      this.loading.resume = true;
       return this.Domain.modifyDnsEntry(this.domain.name, {
         id: this.edit.id,
         fieldType: this.model.fieldType,


### PR DESCRIPTION
Close MBP-296

### Requirements

Clicking the button on the modal multiple times in quick succession causes the same dns record to be added multiple times

## Title of the Pull Requests <!-- required -->


### Multiple DNS Records

This issue has been fixed by blocking the user from clicking the button more than once, by using a loading mask.