### PR TITLE
fix(deps): upgrade ovh-module-emailpro to v7.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ovh-api-services": "^4.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-module-emailpro": "^7.1.5",
+    "ovh-module-emailpro": "^7.1.6",
     "ovh-module-exchange": "^9.3.2",
     "ovh-module-office": "^7.0.6",
     "ovh-module-sharepoint": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7668,10 +7668,10 @@ ovh-manager-webfont@ovh-ux/ovh-manager-webfont#^1.0.1:
   version "1.0.2"
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/1d759c46c8c3ead4bc5e887a2336abd124a17c58"
 
-ovh-module-emailpro@^7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.1.5.tgz#fdd35acea046dd3979fe22fc588e0f192086f08d"
-  integrity sha512-9GWv3zYbzQc8Vp42f/01ooSVZfsIRXfxY/04F/U9WBFtXZOpt+k3UGvQuuYgjbRz2ucO3D1Gx2fCw7G+7xPB8A==
+ovh-module-emailpro@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.1.6.tgz#b248831aac34dd64174e5b1644f549cef7dbdc54"
+  integrity sha512-PARFje5M3krKBloB7o7rZXtDgXN0K6RmyN0FSqEZ77EoIik4Sb9n+9b38K0SAG+L2ATh7vmOxoIpedhW3lLtsw==
   dependencies:
     angular "~1.6.10"
     lodash "~3.9.3"


### PR DESCRIPTION
# ⬆️ Upgrade `ovh-module-emailpro`

### 🎏 Translations

12ced97 - fix(deps): upgrade ovh-module-emailpro to v7.1.6

uses: yarn upgrade-interactive --latest
- ovh-module-emailpro@7.1.6
