### PR TITLE
fix(deps): upgrade ovh-module-exchange to v9.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.1.6",
-    "ovh-module-exchange": "^9.3.2",
+    "ovh-module-exchange": "^9.3.3",
     "ovh-module-office": "^7.0.6",
     "ovh-module-sharepoint": "^7.1.3",
     "ovh-ui-angular": "^2.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7679,10 +7679,10 @@ ovh-module-emailpro@^7.1.6:
     punycode "^1.2.4"
     validator "^4.0.0"
 
-ovh-module-exchange@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.3.2.tgz#3631f56c7f3ec2aa4fe1758ce567c9e84b48f866"
-  integrity sha512-OYV8A13lfUx7R65kWL0O8HxDpwyqEdmkfe2Vi+i3lmMPjGGA7TV2Mg3M0E2HxDH/CQ3PYsC+VbwB7Tl6GIB2xQ==
+ovh-module-exchange@^9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/ovh-module-exchange/-/ovh-module-exchange-9.3.3.tgz#4d889483db8fcd1d6bb388520f037ada8030b1d9"
+  integrity sha512-vec/dBj463gEDcNA+TXVCeeHLnqV3SNTsjioXlDRKJXcS1Z42NfMjyoIu/E6cOvKrT87mYT6cr0Qc9yrbIcedw==
   dependencies:
     filesize "^3.6.1"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade `ovh-module-exchange` to `v9.3.3`

### ⬆️ Upgrade

96f266a - fix(deps): upgrade ovh-module-exchange to v9.3.3

uses: yarn upgrade-interactive --latest
- ovh-module-exchange@9.3.3