### PR TITLE
Increase max dynhost password length from 12 to 31

### DIFF
--- a/client/app/domain/dynhost/login/add/domain-dynhost-login-add.controller.js
+++ b/client/app/domain/dynhost/login/add/domain-dynhost-login-add.controller.js
@@ -14,7 +14,7 @@ angular.module("App").controller(
             this.const = {
                 nbMaxSuffix: 10,
                 nbMinPassword: 8,
-                nbMaxPassword: 12
+                nbMaxPassword: 31
             };
             this.dynHostLogin = { loginSuffix: "", subDomain: "", password: "" };
             this.loading = false;

--- a/client/app/domain/dynhost/login/edit/domain-dynhost-login-edit.controller.js
+++ b/client/app/domain/dynhost/login/edit/domain-dynhost-login-edit.controller.js
@@ -15,7 +15,7 @@ angular.module("App").controller(
 
             this.const = {
                 nbMinPassword: 8,
-                nbMaxPassword: 12
+                nbMaxPassword: 31
             };
             this.data = { password: "" };
             this.loading = false;


### PR DESCRIPTION
## Increase max dynhost password length from 12 to 31


### Description of the Change

Increase max dynhost password length from 12 to 31 to be coherent with API.

### Benefits

Be coherent with API.

### Possible Drawbacks
None

### Applicable Issues
None