### PR TITLE
Add translation for PostGreSQL11

### DIFF
--- a/client/app/private-database/translations/Messages_cs_CZ.xml
+++ b/client/app/private-database/translations/Messages_cs_CZ.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_de_DE.xml
+++ b/client/app/private-database/translations/Messages_de_DE.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5 </translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6 </translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_en_ASIA.xml
+++ b/client/app/private-database/translations/Messages_en_ASIA.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_en_AU.xml
+++ b/client/app/private-database/translations/Messages_en_AU.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_en_CA.xml
+++ b/client/app/private-database/translations/Messages_en_CA.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_en_GB.xml
+++ b/client/app/private-database/translations/Messages_en_GB.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_en_SG.xml
+++ b/client/app/private-database/translations/Messages_en_SG.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_en_US.xml
+++ b/client/app/private-database/translations/Messages_en_US.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_es_ES.xml
+++ b/client/app/private-database/translations/Messages_es_ES.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_es_US.xml
+++ b/client/app/private-database/translations/Messages_es_US.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_fi_FI.xml
+++ b/client/app/private-database/translations/Messages_fi_FI.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_fr_CA.xml
+++ b/client/app/private-database/translations/Messages_fr_CA.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_fr_FR.xml
+++ b/client/app/private-database/translations/Messages_fr_FR.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_it_IT.xml
+++ b/client/app/private-database/translations/Messages_it_IT.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_lt_LT.xml
+++ b/client/app/private-database/translations/Messages_lt_LT.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_nl_NL.xml
+++ b/client/app/private-database/translations/Messages_nl_NL.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_pl_PL.xml
+++ b/client/app/private-database/translations/Messages_pl_PL.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>

--- a/client/app/private-database/translations/Messages_pt_PT.xml
+++ b/client/app/private-database/translations/Messages_pt_PT.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>


### PR DESCRIPTION

### Description of the Change

We added new DBMS PostgreSQL11, but the translation was missing.
adding 1 translation for CloudDatabases order funnel, all languague since it's a commercial name

### Benefits

See before / after :

![after](https://user-images.githubusercontent.com/16922182/55784508-06204480-5ab1-11e9-8eb1-46e322ab6281.png)

![before](https://user-images.githubusercontent.com/16922182/55784510-06204480-5ab1-11e9-8901-e5692c69a93e.png)

