### PR TITLE
translation for postgresql 11

### DIFF
--- a/client/app/private-database/translations/Messages_fr_FR.xml
+++ b/client/app/private-database/translations/Messages_fr_FR.xml
@@ -18,6 +18,7 @@
    <translation id="privateDatabase_dashboard_version_postgresql_95" qtlid="354197">PostgreSQL 9.5</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_96" qtlid="360970">PostgreSQL 9.6</translation>
    <translation id="privateDatabase_dashboard_version_postgresql_10" qtlid="444443">PostgreSQL 10</translation>
+   <translation id="privateDatabase_dashboard_version_postgresql_11">PostgreSQL 11</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_34" qtlid="448301">MongoDB 3.4</translation>
    <translation id="privateDatabase_dashboard_version_redis_32" qtlid="448314">Redis 3.2</translation>
    <translation id="privateDatabase_dashboard_version_mongodb_40" qtlid="506219">MongoDB 4.0</translation>


### PR DESCRIPTION


## Translation for Cloud Databases PostgreSQL 11


### Description of the Change

Adds a translation in the control panel oder funnel for Cloud Databases.

### Benefits

See before/after for explanation :

![before](https://user-images.githubusercontent.com/16922182/56119588-b9cf7b80-5f6c-11e9-8df4-813fad9400d3.png)

After 👍 
![after](https://user-images.githubusercontent.com/16922182/56119665-d9ff3a80-5f6c-11e9-809e-6a9b8b3dc64c.png)
