### PR TITLE
fix(deps): upgrade @ovh-ux/ng-ovh-chatbot to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
-    "@ovh-ux/ng-ovh-chatbot": "^2.0.0-beta.0",
+    "@ovh-ux/ng-ovh-chatbot": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
     "@ovh-ux/ng-ovh-payment-method": "^2.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,10 +1002,10 @@
   dependencies:
     lodash "^4.17.11"
 
-"@ovh-ux/ng-ovh-chatbot@^2.0.0-beta.0":
-  version "2.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-chatbot/-/ng-ovh-chatbot-2.0.0-beta.0.tgz#81485e82b3f94e8139820a77ff01624689fdf2e3"
-  integrity sha512-ny7bXWqsHpROioc3x2YerJBgDTUPd8zsnS6jV5V7Z++ozRfwQl0AkMqoLDCpBOUN82Hw4SXyrINWovm/yG+76Q==
+"@ovh-ux/ng-ovh-chatbot@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-chatbot/-/ng-ovh-chatbot-2.0.0.tgz#9894c2e6baab6f244ecc3722c1a9e469c3f26d28"
+  integrity sha512-UdV33Pg3DfpNv5BUQ8zIV32YvF6Atbk0U9QV91wkFz0OceRb3A9i3JB95PtnCKqRrqpbKlq8dYwWm4BwT16ZpQ==
   dependencies:
     lodash "^4.17.11"
 


### PR DESCRIPTION
# Upgrade @ovh-ux/ng-ovh-chatbot to v2.0.0

### 🐛 Bug Fix

13cad69 - fix(deps): upgrade @ovh-ux/ng-ovh-chatbot to v2.0.0

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-chatbot@2.0.0

### 🏠 Internal

No QA needed (the component now contains the latest retrieve from the translator tool).