### PR TITLE
fix(domain): remove extra angular import statement

### DIFF
--- a/client/app/domain/email-obfuscation/index.js
+++ b/client/app/domain/email-obfuscation/index.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 import component from './email-obfuscation.component';
 import controller from './email-obfuscation.controller';
 

--- a/client/app/domain/optin/index.js
+++ b/client/app/domain/optin/index.js
@@ -1,5 +1,3 @@
-import angular from 'angular';
-
 import component from './optin.component';
 import controller from './optin.controller';
 


### PR DESCRIPTION
# Remove extra angular import statement

It will prevent to load AngularJS more than once.

```txt
WARNING: Tried to load AngularJS more than once.
```

### 🐛 Bug Fix

919dc24 - fix(domain): remove extra angular import statement

### 🏠 Internal

- No QC required.