### PR TITLE
fix(hosting): addition of certificate info in configuration tile

### DIFF
--- a/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
+++ b/client/app/hosting/general-informations/GENERAL_INFORMATIONS.controller.js
@@ -44,8 +44,11 @@ angular.module('App').controller(
       };
 
       this.$scope.$on('hosting.ssl.reload', () => this.retrievingSSLCertificate());
-      return this.$q.all([this.getUserLogsToken(), this.getScreenshot()])
-        .then(() => this.retrievingSSLCertificate())
+      return this.$q.all([
+        this.getUserLogsToken(),
+        this.getScreenshot(),
+        this.retrievingSSLCertificate(),
+      ])
         .then(() => this.HostingRuntimes.getDefault(this.serviceName))
         .then((runtime) => {
           this.defaultRuntime = runtime;
@@ -160,7 +163,7 @@ angular.module('App').controller(
       if (
         this.hostingSSLCertificate.constructor.testCanBeHandled(this.sslCertificate)
       ) {
-        return this.$translate.instant('common_yes');
+        return `${this.$translate.instant('common_yes')} - ${this.sslCertificate.provider} - ${this.sslCertificate.type}`;
       }
 
       return this.$translate.instant(`hosting_dashboard_service_ssl_${this.sslCertificate.status}`);


### PR DESCRIPTION
MBP-347

### Requirements

The certificate provider and type has to be added to the configuration tile, instead of just "Yes"

## Addition of certificate info in configuration tile

### Description of the Change

The above mentioned information has been added to the hosting configuration tile.