### PR TITLE
fix(domain): add missing translations

### DIFF
--- a/client/app/domain/translations/Messages_fr_FR.xml
+++ b/client/app/domain/translations/Messages_fr_FR.xml
@@ -41,6 +41,9 @@
    <translation id="domain_dashboard_whois" qtlid="522682">Affichage du WHOIS</translation>
    <translation id="domain_dashboard_whois_button" qtlid="522695">Configurer l'affichage du WHOIS</translation>
    <translation id="domain_dashboard_whois_not_allowed" qtlid="522708">Le registre en charge de ce nom de domaine n'autorise pas l'affichage de vos données personnalisées</translation>
+   <translation id="domain_dashboard_whois_pending">Ce service est en cours de création. Merci de patienter.</translation>
+   <translation id="domain_dashboard_whois_invalid_contact">Seul le contact administrateur est autorisé à effectuer cette action.</translation>
+   <translation id="domain_dashboard_whois_error">Une erreur est survenue. Veuillez réessayer ultérieurement.</translation>
 
    <translation id="domain_dashboard_obfuscated_email" qtlid="522721">Adresses e-mails de substitution</translation>
    <translation id="domain_dashboard_obfuscated_email_regenerate_button" qtlid="522734">Gérer les e-mails de substitution</translation>


### PR DESCRIPTION
## Add missing translations for Domain Whois 

Translations were accidentally removed with 0851ea9032205813e470b8526e3b994827690169


MANAGER-2565
