### PR TITLE
fix(hosting-cron): new languages addition

### DIFF
--- a/client/app/hosting/cron/CRON.html
+++ b/client/app/hosting/cron/CRON.html
@@ -110,7 +110,7 @@
                                     <th class="word-break" scope="row" data-ng-bind="cron.command"></th>
                                     <td class="word-break" data-ng-bind="cron.description"></td>
                                     <td class="text-nowrap" data-ng-bind="cron.frequency"></td>
-                                    <td data-ng-bind="'hosting_tab_CRON_table_language_' + trEnum(cron.language) | translate"></td>
+                                    <td data-ng-bind="(('hosting_tab_CRON_table_language_' + trEnum(cron.language) | translate) == 'hosting_tab_CRON_table_language_' + trEnum(cron.language))? cron.language: ('hosting_tab_CRON_table_language_' + trEnum(cron.language) | translate)"></td>
                                     <td>
                                         <span class="oui-status"
                                               data-ng-bind="'hosting_tab_CRON_table_status_' + trEnum(cron.status) | translate"

--- a/client/app/hosting/translations/Messages_fr_FR.xml
+++ b/client/app/hosting/translations/Messages_fr_FR.xml
@@ -289,6 +289,16 @@
    <translation id="hosting_tab_CRON_table_language_php7_1" qtlid="434174">PHP 7.1</translation>
    <translation id="hosting_tab_CRON_table_language_PHP_7_2" qtlid="448249">PHP 7.2</translation>
    <translation id="hosting_tab_CRON_table_language_php7_2" qtlid="448249">PHP 7.2</translation>
+   <translation id="hosting_tab_CRON_table_language_PHP_7_3">PHP 7.3</translation>
+   <translation id="hosting_tab_CRON_table_language_php7_3">PHP 7.3</translation>
+   <translation id="hosting_tab_CRON_table_language_NODE_8">Node 8</translation>
+   <translation id="hosting_tab_CRON_table_language_node8">Node 8</translation>
+   <translation id="hosting_tab_CRON_table_language_NODE_9">Node 9</translation>
+   <translation id="hosting_tab_CRON_table_language_node9">Node 9</translation>
+   <translation id="hosting_tab_CRON_table_language_NODE_10">Node 10</translation>
+   <translation id="hosting_tab_CRON_table_language_node10">Node 10</translation>
+   <translation id="hosting_tab_CRON_table_language_NODE_11">Node 11</translation>
+   <translation id="hosting_tab_CRON_table_language_node11">Node 11</translation>
    <translation id="hosting_tab_CRON_table_popover_delete" qtlid="2414">Supprimer</translation>
    <translation id="hosting_tab_CRON_table_popover_modify" qtlid="37875">Modifier</translation>
    <translation id="hosting_tab_CRON_configuration_error" qtlid="244690">Une erreur est survenue lors de la récupération des données :</translation>


### PR DESCRIPTION
MBP-382

### Requirements

The table listing the cron jobs for a hosting, does not display the language properly for php7.3, node8, node9, node10 and node11

## Title of the Pull Requests <!-- required -->

### Description of the Change

Addition of translations for php7.3, node8, node9, node10, node11 languages