### PR TITLE
fix(modules-1-click): fix 1 click modules

### DIFF
--- a/client/app/hosting/module/delete/hosting-module-delete.controller.js
+++ b/client/app/hosting/module/delete/hosting-module-delete.controller.js
@@ -29,7 +29,7 @@ angular.module('App').controller(
         .catch((err) => {
           this.Alerter.alertFromSWS(
             this.$translate.instant('hosting_configuration_tab_modules_delete_fail', {
-              t0: this.moduleToDelete,
+              t0: this.moduleToDelete.template.name,
             }),
             err,
             this.$scope.alerts.main,

--- a/client/app/hosting/module/hosting-module.service.js
+++ b/client/app/hosting/module/hosting-module.service.js
@@ -104,7 +104,6 @@
       getModules(serviceName, opts) {
         return this.OvhHttp.get(`/hosting/web/${serviceName}/module`, {
           rootPath: 'apiv6',
-          cache: cache.installedModules,
           clearCache: opts.forceRefresh,
         });
       }


### PR DESCRIPTION
## Fix for installing 1-click module polling


### Description of the Change

remove loading from cache
fix delete error message

### Benefits

Helps view module which is being installed without page refresh
Error message looks neat

### Possible Drawbacks

None

### Applicable Issues

resolves MBP-353
