### PR TITLE
fix(deps): upgrade ng-ovh-otrs to v7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-chatbot": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.0.2",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.3",
     "@ovh-ux/ng-ovh-payment-method": "^2.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,10 +1045,10 @@
     lodash "~4.17.11"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.0.2.tgz#1406d17e64a920e6cf5be2950ba0acc1aaa364a1"
-  integrity sha512-2e9TyXilq3PX+V9vgzjx5m6Q/JAE3MyFACfulFFiaqJRWtci2QmeZbTdPo1jqlYH1op79j0qTVzt0KZe3CG1pQ==
+"@ovh-ux/ng-ovh-otrs@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.3.tgz#eac13775586a5f9249e331c1de846b9d51fcae7b"
+  integrity sha512-/Ku1LSjf1kxf68tVX3+oBhfImIgsk+4KN2Ul1dxzlTfLO+WC0pNblnge+kTO4mKkc0fmu7A2QMEc2iuR/2joUQ==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade ng-ovh-otrs to v7.1.3

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-otrs@7.1.3

### :house: Internal

- No QC required.