### PR TITLE
fix(deps): upgrade ng-ovh-otrs to v7.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
     "@ovh-ux/ng-ovh-chatbot": "^2.0.0",
     "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.3",
+    "@ovh-ux/ng-ovh-otrs": "^7.1.4",
     "@ovh-ux/ng-ovh-payment-method": "^2.0.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-responsive-popover": "^5.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,10 +1045,10 @@
     lodash "~4.17.11"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.3.tgz#eac13775586a5f9249e331c1de846b9d51fcae7b"
-  integrity sha512-/Ku1LSjf1kxf68tVX3+oBhfImIgsk+4KN2Ul1dxzlTfLO+WC0pNblnge+kTO4mKkc0fmu7A2QMEc2iuR/2joUQ==
+"@ovh-ux/ng-ovh-otrs@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.4.tgz#e49c9696dc9a86281ae4bd3f71c43c1fc4a7a36c"
+  integrity sha512-z+h5clMBoB/9Mxd+k15PLkeZMKQbDKpoPfztaPhcHJBsaK9aJWUZPN2YdxOc1Im4dWkWI4soPF+zI1wFdQGBhA==
   dependencies:
     draggable "^4.2.0"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade ng-ovh-otrs to v7.1.4

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/ng-ovh-otrs@7.1.4

### :house: Internal

- No QC required.