### PR TITLE
fix(deps): upgrade ovh-module-emailpro to v7.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "ovh-api-services": "^6.18.1",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-module-emailpro": "^7.2.5",
+    "ovh-module-emailpro": "^7.2.6",
     "ovh-module-exchange": "^9.4.5",
     "ovh-module-office": "^7.0.8",
     "ovh-module-sharepoint": "^7.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7799,10 +7799,10 @@ ovh-manager-webfont@ovh-ux/ovh-manager-webfont#^1.0.1:
   version "1.0.2"
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/1d759c46c8c3ead4bc5e887a2336abd124a17c58"
 
-ovh-module-emailpro@^7.2.5:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.2.5.tgz#e4d20054642f4e7ad15ed196af9da8f77c129d41"
-  integrity sha512-GyWuNHWpmMFPp9No1jbBo4BaeMhYXDbDJ6NtsFShBb1d8RhQ4EFu8lbBNNeWEe0zg+1q5Ul36QLBwBHMzT+noQ==
+ovh-module-emailpro@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.2.6.tgz#297d4e0699d4b767e07857e8b05483532575d442"
+  integrity sha512-l89LFc5ggz7TyigosncjYrvLv9ea5V4UE1no2Nb9OF+S7891Lvk2lweA8Z7bqYiKcsgosNlcrE7N+q/3LMuDbQ==
   dependencies:
     angular "~1.6.10"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade ovh-module-emailpro to v7.2.6

### :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-module-emailpro@7.2.6

### :house: Internal

- No QC required.