### PR TITLE
fix(deps): upgrade manager-server-sidebar to v0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^6.0.0",
     "@ovh-ux/manager-navbar": "^1.0.0",
-    "@ovh-ux/manager-server-sidebar": "^0.2.1",
+    "@ovh-ux/manager-server-sidebar": "^0.2.2",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,10 +1109,10 @@
     lodash "^4.17.11"
     moment "^2.24.0"
 
-"@ovh-ux/manager-server-sidebar@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.2.1.tgz#145aefe732a6aa84e759c81660cc03dcd9c6f2a2"
-  integrity sha512-b/xkr/bWtBvMSwCG5h2eU257tay8vAOxKRV+xGftLWAmTJ87WWIk7i3HxM02hdfK6sHQKZ5TvWTFbm33A4BmoA==
+"@ovh-ux/manager-server-sidebar@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.2.2.tgz#45337fdddbb1e8ac66cfba41b7fb1871f1408665"
+  integrity sha512-bvHIcgc2ifsb1ROBYxj7KXaWmRUSVDf45EKq21X62EItWOshVGkFwUJce9w4irRXO1HjUP/GULTeiXl/Kw2KBw==
   dependencies:
     jsurl "^0.1.5"
     lodash "^4.17.11"


### PR DESCRIPTION
# Upgrade manager-server-sidebar to v0.2.2

###:arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- @ovh-ux/manager-server-sidebar@0.2.2

### :house: Internal

- No QC required.
