### PR TITLE
fix(hosting): allow field for runtime for all new languages except phfpm

### DIFF
--- a/client/app/hosting/popover/multisite.html
+++ b/client/app/hosting/popover/multisite.html
@@ -1,7 +1,7 @@
 <div class="popover-menu">
     <oui-button data-variant="link" class="d-block"
             data-on-click="modifyDomain(domain)"
-            data-disabled="domain.status === status.UPDATING"
+            data-disabled="domain.status !== status.CREATED"
             data-ng-if="excludeAttachedDomains.indexOf(domain.displayName) === -1">
             <span data-translate="hosting_tab_DOMAINS_table_popover_modify"></span>
     </oui-button>
@@ -20,13 +20,13 @@
     </div>
     <oui-button data-variant="link" class="d-block"
             data-on-click="detachDomain(domain)"
-            data-disabled="domain.status === status.UPDATING"
+            data-disabled="domain.status !== status.CREATED"
             data-ng-if="excludeAttachedDomains.indexOf(domain.displayName) === -1">
             <span data-translate="hosting_tab_DOMAINS_table_popover_delete"></span>
     </oui-button>
     <oui-button data-variant="link" class="d-block"
                 data-ng-if="hosting.isCloudWeb"
-                data-disabled="domain.status === status.UPDATING || domain.runtime.type.indexOf(runtimeNode) < 0"
+                data-disabled="domain.status !== status.CREATED"
                 data-on-click="restartDomain(domain)">
                 <span data-translate="hosting_tab_DOMAINS_table_popover_restart"></span>
     </oui-button>

--- a/client/app/hosting/runtimes/add/hosting-runtimes-add.controller.js
+++ b/client/app/hosting/runtimes/add/hosting-runtimes-add.controller.js
@@ -47,7 +47,7 @@ angular.module('App').controller(
       if (
         this.entryToCreate
         && this.entryToCreate.type
-        && this.entryToCreate.type.indexOf('nodejs') !== -1
+        && this.entryToCreate.type.indexOf('phpfpm') === -1
       ) {
         return (
           this.entryToCreate

--- a/client/app/hosting/runtimes/add/hosting-runtimes-add.html
+++ b/client/app/hosting/runtimes/add/hosting-runtimes-add.html
@@ -40,7 +40,7 @@
                     </div>
                 </div>
 
-                <div data-ng-if="ctrl.entryToCreate.type.length && ctrl.entryToCreate.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="ctrl.entryToCreate.type.length && ctrl.entryToCreate.type.indexOf('phpfpm') === -1">
                     <div class="form-group">
                         <label class="control-label col-md-4 required" for="runtimePublicDir" data-translate="hosting_tab_RUNTIMES_label_publicDir"></label>
 

--- a/client/app/hosting/runtimes/delete/hosting-runtimes-delete.html
+++ b/client/app/hosting/runtimes/delete/hosting-runtimes-delete.html
@@ -14,7 +14,7 @@
                 <dt data-translate="hosting_tab_RUNTIMES_table_header_language"></dt>
                 <dd data-ng-bind="ctrl.entryToDelete.type"></dd>
 
-                <div data-ng-if="ctrl.entryToDelete.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="ctrl.entryToDelete.type.indexOf('phpfpm') === -1">
                     <dt data-translate="hosting_tab_RUNTIMES_table_header_publicDir"></dt>
                     <dd data-ng-bind="ctrl.entryToDelete.publicDir"></dd>
 

--- a/client/app/hosting/runtimes/edit/hosting-runtimes-edit.controller.js
+++ b/client/app/hosting/runtimes/edit/hosting-runtimes-edit.controller.js
@@ -44,7 +44,7 @@ angular.module('App').controller(
       if (
         this.entryToEdit
         && this.entryToEdit.type
-        && this.entryToEdit.type.indexOf('nodejs') !== -1
+        && this.entryToEdit.type.indexOf('phpfpm') === -1
       ) {
         return (
           this.entryToEdit

--- a/client/app/hosting/runtimes/edit/hosting-runtimes-edit.html
+++ b/client/app/hosting/runtimes/edit/hosting-runtimes-edit.html
@@ -32,7 +32,7 @@
                     </div>
                 </div>
 
-                <div data-ng-if="ctrl.entryToEdit.type.length && ctrl.entryToEdit.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="ctrl.entryToEdit.type.length && ctrl.entryToEdit.type.indexOf('phpfpm') === -1">
                     <div class="form-group">
                         <label class="control-label col-md-4 required" for="runtimePublicDir" data-translate="hosting_tab_RUNTIMES_label_publicDir"></label>
 

--- a/client/app/hosting/runtimes/set-default/hosting-runtimes-set-default.html
+++ b/client/app/hosting/runtimes/set-default/hosting-runtimes-set-default.html
@@ -14,7 +14,7 @@
                 <dt data-translate="hosting_tab_RUNTIMES_table_header_language"></dt>
                 <dd data-ng-bind="ctrl.entryToSetup.type"></dd>
 
-                <div data-ng-if="ctrl.entryToSetup.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="ctrl.entryToSetup.type.indexOf('phpfpm') === -1">
                     <dt data-translate="hosting_tab_RUNTIMES_table_header_publicDir"></dt>
                     <dd data-ng-bind="ctrl.entryToSetup.publicDir"></dd>
 


### PR DESCRIPTION
## cloud web: allow field for runtime for all new languages except phfpm

### Description of the Change

3af34be  : Replace "only for nodejs" by "except phpfpm"

### Possible Drawbacks

- Change restart behavior into multisites tab popover
- Change runtime add/edit behavior for the form for phpfpm and/or nodejs/python/ruby

MBP-480


