### PR TITLE
fix(cloudweb): display fields for every language except php

### DIFF
--- a/client/app/hosting/hosting.constant.js
+++ b/client/app/hosting/hosting.constant.js
@@ -1,11 +1,24 @@
-angular.module('App').constant('HOSTING', {
-  cloudWeb: {
-    configurationQuota: {
-      unit: 'GB',
-      value: 15,
+angular
+  .module('App')
+  .constant('HOSTING', {
+    cloudWeb: {
+      configurationQuota: {
+        unit: 'GB',
+        value: 15,
+      },
     },
-  },
-  offers: {
-    START_10_M: 'START_10_M',
-  },
-});
+    offers: {
+      START_10_M: 'START_10_M',
+    },
+  })
+  .constant('HOSTING_RUNTIME', {
+    NODE: 'nodejs',
+    PHP: 'phpfpm',
+  })
+  .constant('HOSTING_STATUS', {
+    CREATED: 'created',
+    CREATING: 'creating',
+    DELETING: 'deleting',
+    REGENERATING: 'regenerating',
+    UPDATING: 'updating',
+  });

--- a/client/app/hosting/hosting.controller.js
+++ b/client/app/hosting/hosting.controller.js
@@ -20,6 +20,7 @@ angular
       HostingDomain,
       PrivateDatabase,
       $stateParams,
+      HOSTING_STATUS,
     ) => {
       $scope.loadingHostingInformations = true;
       $scope.loadingHostingError = false;
@@ -29,6 +30,8 @@ angular
       $scope.edit = {
         active: false,
       };
+
+      $scope.HOSTING_STATUS = HOSTING_STATUS;
 
       $scope.stepPath = '';
       $scope.currentAction = null;

--- a/client/app/hosting/multisite/MULTISITE.html
+++ b/client/app/hosting/multisite/MULTISITE.html
@@ -79,7 +79,7 @@
                             <tr data-ng-repeat="domain in domains.list.results track by $index">
                                 <td class="word-break">
                                     <span data-ng-bind="::domain.displayName"></span>
-                                    <oui-spinner data-size="s" data-ng-if="hosting.isCloudWeb && domain.status === status.UPDATING"></oui-spinner>
+                                    <oui-spinner data-size="s" data-ng-if="hosting.isCloudWeb && domain.status === HOSTING_STATUS.UPDATING"></oui-spinner>
                                 </td>
                                 <td data-ng-bind="domain.path"></td>
                                 <td data-ng-if="hosting.isCloudWeb" data-ng-bind="domain.runtime.name"></td>
@@ -186,7 +186,7 @@
                     data-ng-click="setAction('ssl/order/hosting-order-ssl')"
                     data-ng-disabled="sslCertificate && isSSLCertificateOperationInProgress(sslCertificate)">
                     <span data-translate="hosting_dashboard_service_order_ssl"></span>
-                    <oui-spinner data-size="s" data-ng-if="status.regeneratingSsl"></oui-spinner>
+                    <oui-spinner data-size="s" data-ng-if="loading.regeneratingSsl"></oui-spinner>
                 </button>
                 <button
                     type="button"
@@ -196,7 +196,7 @@
                         && isLetsEncryptCertificate(sslCertificate)
                         && isSSLCertificateOperationInProgress(sslCertificate)">
                         <span data-translate="hosting_ssl_regenerate_title_button"></span>
-                        <oui-spinner data-size="s" data-ng-if="status.regeneratingSsl"></oui-spinner>
+                        <oui-spinner data-size="s" data-ng-if="loading.regeneratingSsl"></oui-spinner>
                 </button>
             </div>
         </aside>

--- a/client/app/hosting/popover/multisite.html
+++ b/client/app/hosting/popover/multisite.html
@@ -1,7 +1,7 @@
 <div class="popover-menu">
     <oui-button data-variant="link" class="d-block"
             data-on-click="modifyDomain(domain)"
-            data-disabled="domain.status === status.UPDATING"
+            data-disabled="domain.status !== HOSTING_STATUS.CREATED"
             data-ng-if="excludeAttachedDomains.indexOf(domain.displayName) === -1">
             <span data-translate="hosting_tab_DOMAINS_table_popover_modify"></span>
     </oui-button>
@@ -20,13 +20,13 @@
     </div>
     <oui-button data-variant="link" class="d-block"
             data-on-click="detachDomain(domain)"
-            data-disabled="domain.status === status.UPDATING"
+            data-disabled="domain.status !== HOSTING_STATUS.CREATED"
             data-ng-if="excludeAttachedDomains.indexOf(domain.displayName) === -1">
             <span data-translate="hosting_tab_DOMAINS_table_popover_delete"></span>
     </oui-button>
     <oui-button data-variant="link" class="d-block"
                 data-ng-if="hosting.isCloudWeb"
-                data-disabled="domain.status === status.UPDATING || domain.runtime.type.indexOf(runtimeNode) < 0"
+                data-disabled="domain.status !== HOSTING_STATUS.CREATED"
                 data-on-click="restartDomain(domain)">
                 <span data-translate="hosting_tab_DOMAINS_table_popover_restart"></span>
     </oui-button>

--- a/client/app/hosting/runtimes/add/hosting-runtimes-add.controller.js
+++ b/client/app/hosting/runtimes/add/hosting-runtimes-add.controller.js
@@ -1,13 +1,15 @@
 angular.module('App').controller(
   'controllers.Hosting.Runtimes.create',
   class HostingRuntimesCreateCtrl {
-    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes) {
+    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes, HOSTING_RUNTIME) {
       this.$scope = $scope;
       this.$stateParams = $stateParams;
       this.$translate = $translate;
 
       this.Alerter = Alerter;
       this.HostingRuntimes = HostingRuntimes;
+
+      this.HOSTING_RUNTIME = HOSTING_RUNTIME;
     }
 
     $onInit() {
@@ -45,9 +47,8 @@ angular.module('App').controller(
 
     isValid() {
       if (
-        this.entryToCreate
-        && this.entryToCreate.type
-        && this.entryToCreate.type.indexOf('nodejs') !== -1
+        _.has(this, 'entryToCreate.type')
+        && !this.entryToCreate.type.includes(this.HOSTING_RUNTIME.PHP)
       ) {
         return (
           this.entryToCreate

--- a/client/app/hosting/runtimes/add/hosting-runtimes-add.html
+++ b/client/app/hosting/runtimes/add/hosting-runtimes-add.html
@@ -40,7 +40,7 @@
                     </div>
                 </div>
 
-                <div data-ng-if="ctrl.entryToCreate.type.length && ctrl.entryToCreate.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="ctrl.entryToCreate.type.length && !ctrl.entryToCreate.type.includes(ctrl.HOSTING_RUNTIME.PHP)">
                     <div class="form-group">
                         <label class="control-label col-md-4 required" for="runtimePublicDir" data-translate="hosting_tab_RUNTIMES_label_publicDir"></label>
 

--- a/client/app/hosting/runtimes/delete/hosting-runtimes-delete.controller.js
+++ b/client/app/hosting/runtimes/delete/hosting-runtimes-delete.controller.js
@@ -1,13 +1,15 @@
 angular.module('App').controller(
   'controllers.Hosting.Runtimes.delete',
   class HostingRuntimesDeleteCtrl {
-    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes) {
+    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes, HOSTING_RUNTIME) {
       this.$scope = $scope;
       this.$stateParams = $stateParams;
       this.$translate = $translate;
 
       this.Alerter = Alerter;
       this.HostingRuntimes = HostingRuntimes;
+
+      this.HOSTING_RUNTIME = HOSTING_RUNTIME;
     }
 
     $onInit() {

--- a/client/app/hosting/runtimes/delete/hosting-runtimes-delete.html
+++ b/client/app/hosting/runtimes/delete/hosting-runtimes-delete.html
@@ -14,7 +14,7 @@
                 <dt data-translate="hosting_tab_RUNTIMES_table_header_language"></dt>
                 <dd data-ng-bind="ctrl.entryToDelete.type"></dd>
 
-                <div data-ng-if="ctrl.entryToDelete.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="!ctrl.entryToDelete.type.includes(ctrl.HOSTING_RUNTIME.PHP)">
                     <dt data-translate="hosting_tab_RUNTIMES_table_header_publicDir"></dt>
                     <dd data-ng-bind="ctrl.entryToDelete.publicDir"></dd>
 

--- a/client/app/hosting/runtimes/edit/hosting-runtimes-edit.controller.js
+++ b/client/app/hosting/runtimes/edit/hosting-runtimes-edit.controller.js
@@ -1,13 +1,15 @@
 angular.module('App').controller(
   'controllers.Hosting.Runtimes.edit',
   class HostingRuntimesEditCtrl {
-    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes) {
+    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes, HOSTING_RUNTIME) {
       this.$scope = $scope;
       this.$stateParams = $stateParams;
       this.$translate = $translate;
 
       this.Alerter = Alerter;
       this.HostingRuntimes = HostingRuntimes;
+
+      this.HOSTING_RUNTIME = HOSTING_RUNTIME;
     }
 
     $onInit() {
@@ -42,9 +44,8 @@ angular.module('App').controller(
 
     isValid() {
       if (
-        this.entryToEdit
-        && this.entryToEdit.type
-        && this.entryToEdit.type.indexOf('nodejs') !== -1
+        _.has(this, 'entryToEdit.type')
+        && !this.entryToEdit.type.includes(this.HOSTING_RUNTIME.PHP)
       ) {
         return (
           this.entryToEdit

--- a/client/app/hosting/runtimes/edit/hosting-runtimes-edit.html
+++ b/client/app/hosting/runtimes/edit/hosting-runtimes-edit.html
@@ -32,7 +32,7 @@
                     </div>
                 </div>
 
-                <div data-ng-if="ctrl.entryToEdit.type.length && ctrl.entryToEdit.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="ctrl.entryToEdit.type.length && !ctrl.entryToEdit.type.includes(ctrl.HOSTING_RUNTIME.PHP)">
                     <div class="form-group">
                         <label class="control-label col-md-4 required" for="runtimePublicDir" data-translate="hosting_tab_RUNTIMES_label_publicDir"></label>
 

--- a/client/app/hosting/runtimes/set-default/hosting-runtimes-set-default.controller.js
+++ b/client/app/hosting/runtimes/set-default/hosting-runtimes-set-default.controller.js
@@ -1,13 +1,15 @@
 angular.module('App').controller(
   'controllers.Hosting.Runtimes.setDefault',
   class HostingRuntimesSetDefaultCtrl {
-    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes) {
+    constructor($scope, $stateParams, $translate, Alerter, HostingRuntimes, HOSTING_RUNTIME) {
       this.$scope = $scope;
       this.$stateParams = $stateParams;
       this.$translate = $translate;
 
       this.Alerter = Alerter;
       this.HostingRuntimes = HostingRuntimes;
+
+      this.HOSTING_RUNTIME = HOSTING_RUNTIME;
     }
 
     $onInit() {

--- a/client/app/hosting/runtimes/set-default/hosting-runtimes-set-default.html
+++ b/client/app/hosting/runtimes/set-default/hosting-runtimes-set-default.html
@@ -14,7 +14,7 @@
                 <dt data-translate="hosting_tab_RUNTIMES_table_header_language"></dt>
                 <dd data-ng-bind="ctrl.entryToSetup.type"></dd>
 
-                <div data-ng-if="ctrl.entryToSetup.type.indexOf('nodejs') !== -1">
+                <div data-ng-if="!ctrl.entryToSetup.type.includes(ctrl.HOSTING_RUNTIME.PHP)">
                     <dt data-translate="hosting_tab_RUNTIMES_table_header_publicDir"></dt>
                     <dd data-ng-bind="ctrl.entryToSetup.publicDir"></dd>
 


### PR DESCRIPTION
## Possible Drawbacks
- Change restart behavior into multisites tab popover
- Change runtime add/edit behavior for the form for phpfpm and/or nodejs/python/ruby

MBP-480