### PR TITLE
build: bump @ovh-ux/manager-server-sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@ovh-ux/manager-config": "^0.2.0",
     "@ovh-ux/manager-core": "^6.0.1",
     "@ovh-ux/manager-navbar": "^1.1.0",
-    "@ovh-ux/manager-server-sidebar": "^0.3.1",
+    "@ovh-ux/manager-server-sidebar": "^0.3.2",
     "@ovh-ux/ng-at-internet": "^4.0.0",
     "@ovh-ux/ng-at-internet-ui-router-plugin": "^2.0.0",
     "@ovh-ux/ng-ovh-actions-menu": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,10 +1109,10 @@
     lodash "^4.17.11"
     moment "^2.24.0"
 
-"@ovh-ux/manager-server-sidebar@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.3.1.tgz#cf8305ffd7439d6a958826d453d5583d4dce8423"
-  integrity sha512-Zdd32jQgaZrk+E3V6pXnI7garKN3/0d5pgedQD56ENxNct/q/r2gm14py0+U1WsOEQcCmrw151mzFfSM3EnVRw==
+"@ovh-ux/manager-server-sidebar@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@ovh-ux/manager-server-sidebar/-/manager-server-sidebar-0.3.2.tgz#f9ad745ea9ff9fe6aa65950dd4fd6c15f4102764"
+  integrity sha512-XHegD7M8Db5zq/rPydn0hVoMbjtHnuTo6UwP5PWwtN0coCkWHu0RzkHOy8cQ2gRCclFJVeIlpfOv/Hxqsju2wA==
   dependencies:
     jsurl "^0.1.5"
     lodash "^4.17.11"


### PR DESCRIPTION
## build: bump @ovh-ux/manager-server-sidebar

### Description of the Change

* bump `@ovh-ux/manager-server-sidebar` from `^0.3.1` to `^0.3.2`

1ac863bc — build: bump @ovh-ux/manager-server-sidebar

ref: DTRUN-2117, DTRUN-2134


