### PR TITLE
build(deps): upgrade ovh-api-services to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "ovh-angular-responsive-tabs": "ovh-ux/ovh-angular-responsive-tabs#^4.0.0",
     "ovh-angular-tail-logs": "^1.1.1",
     "ovh-angular-toaster": "ovh-ux/ovh-angular-toaster#^0.8.0",
-    "ovh-api-services": "^6.32.0",
+    "ovh-api-services": "^7.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8185,10 +8185,10 @@ ovh-angular-toaster@ovh-ux/ovh-angular-toaster#^0.8.0:
   version "0.8.0"
   resolved "https://codeload.github.com/ovh-ux/ovh-angular-toaster/tar.gz/06d24889e94b8d816afee8e94185697cf68f2338"
 
-ovh-api-services@^6.32.0:
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-6.32.0.tgz#b3f9abe947224bfdf644586a52147d75971583b6"
-  integrity sha512-QFFTsOM6mjzUMIur96gXLm5IPw5OzL/DaQuEq03n7Y+zqP+rNvnvDZC65c1NMSKZfvkfJVigA/wcNxx6vk9jNg==
+ovh-api-services@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-7.0.0.tgz#240ced6f8930eed94b4484aa558ad8f432af537f"
+  integrity sha512-aC2NDo9Rf7iwJvfnoPJ2E9Rtrv7Yy7tNXFJv4PifBqyUefjbTAUCfDNRrxgVnpOmPJ1h5SWjx19t3T/6w8qVDw==
   dependencies:
     lodash "^3.10.1"
 


### PR DESCRIPTION
# Upgrade ovh-api-services to v7.0.0

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-api-services@7.0.0

## :link: Related

- ovh-ux/ovh-api-services#191

## :house: Internal

- No QC required.