### PR TITLE
fix(deps): upgrade ovh-module-emailpro to v7.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "ovh-api-services": "^7.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
-    "ovh-module-emailpro": "^7.2.7",
+    "ovh-module-emailpro": "^7.2.8",
     "ovh-module-exchange": "^9.4.5",
     "ovh-module-office": "^7.0.8",
     "ovh-module-sharepoint": "^7.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,10 +8200,10 @@ ovh-manager-webfont@ovh-ux/ovh-manager-webfont#^1.0.1:
   version "1.0.2"
   resolved "https://codeload.github.com/ovh-ux/ovh-manager-webfont/tar.gz/1d759c46c8c3ead4bc5e887a2336abd124a17c58"
 
-ovh-module-emailpro@^7.2.7:
-  version "7.2.7"
-  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.2.7.tgz#024ce708c6e21399e4d7366d7512cb640939abf1"
-  integrity sha512-eYQsSj3PZMkNodUphXXSI+XyeIX7NYzNQ8x1UcsTxul/AkdrmKudkmmAofMm0eLCUJezXubpcpiWmEqtKVWP5A==
+ovh-module-emailpro@^7.2.8:
+  version "7.2.8"
+  resolved "https://registry.yarnpkg.com/ovh-module-emailpro/-/ovh-module-emailpro-7.2.8.tgz#698374c1d5538e2cdce274762d4365bb83531d05"
+  integrity sha512-EF/Wl79mcuvwRnCNMvF4uY7foK3vxbn6PWG59uHx7VFrfp6pf0giNk4K6drdxUuLMDjG/1HujYHKFJDNacFkjw==
   dependencies:
     angular "~1.6.10"
     lodash "~3.9.3"


### PR DESCRIPTION
# Upgrade ovh-module-emailpro to v7.2.8

## :arrow_up: Upgrade

uses: yarn upgrade-interactive --latest
- ovh-module-emailpro@7.2.8

## :link: Related

- ovh-ux/ovh-module-emailpro#222

## :house: Internal

- No QC required.

ref: MBP-384, TRANS-16421