### PR TITLE
fix(domain-options): addition of options tile

### DIFF
--- a/client/app/domain/domain.constant.js
+++ b/client/app/domain/domain.constant.js
@@ -11,13 +11,20 @@ export const WHOIS_ALL_CONTACT_OPTIN_RULE = [
   'domain',
 ];
 
+export const DOMAIN_OPTION_STATUS = {
+  ACTIVE: 'subscribed',
+  INACTIVE: 'released',
+};
+
 export default {
   ALERTS,
   WHOIS_STATUS,
   WHOIS_ALL_CONTACT_OPTIN_RULE,
+  DOMAIN_OPTION_STATUS,
 };
 
 angular.module('App').constant('DOMAIN', {
   ALERTS,
   WHOIS_STATUS,
+  DOMAIN_OPTION_STATUS,
 });

--- a/client/app/domain/domain.service.js
+++ b/client/app/domain/domain.service.js
@@ -1177,6 +1177,40 @@ angular.module('services').service(
       });
     }
 
+    // --------------------- Options ----------------------------
+
+    /**
+     * Get all options
+     * @param {string} serviceName
+     */
+    getOptions(serviceName) {
+      return this.OvhHttp.get(`/domain/${serviceName}/option`, {
+        rootPath: 'apiv6',
+      });
+    }
+
+    /**
+     * Get the option details
+     * @param {string} serviceName
+     * @param {string} option
+     */
+    getOption(serviceName, option) {
+      return this.OvhHttp.get(`/domain/${serviceName}/option/${option}`, {
+        rootPath: 'apiv6',
+      });
+    }
+
+    /**
+     * Delete option
+     * @param {string} serviceName
+     * @param {string} option
+     */
+    deleteOption(serviceName, option) {
+      return this.OvhHttp.delete(`/domain/${serviceName}/option/${option}`, {
+        rootPath: 'apiv6',
+      });
+    }
+
     // --------------------- Glue registry ----------------------
 
     /**

--- a/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
+++ b/client/app/domain/general-informations/GENERAL_INFORMATIONS.html
@@ -1,7 +1,7 @@
 <div class="container-fluid px-0" data-ng-controller="DomainTabGeneralInformationsCtrl as $ctrl">
     <div data-ovh-alert="{{alerts.main}}"></div>
     <div class="row d-lg-flex">
-        <div class="col-xm-12 col-md-4 mb-5">
+        <div class="col-md-4 mb-5">
             <oui-tile
                 data-heading="{{ ::'domain_dashboard_general_informations' | translate }}"
                 class="h-100"
@@ -130,7 +130,7 @@
                 </oui-tile-definition>
             </oui-tile>
         </div>
-        <div class="col-xm-12 col-md-4 mb-5">
+        <div class="col-md-4 mb-5">
             <oui-tile
                 data-heading="{{ ::'domain_dashboard_security' | translate }}"
                 class="h-100"
@@ -202,7 +202,7 @@
                 </oui-tile-definition>
             </oui-tile>
         </div>
-        <div class="col-xm-12 col-md-4 mb-5">
+        <div class="col-md-4 mb-5">
             <div class="mb-5" data-ng-if="$ctrl.screenshot">
                 <oui-spinner data-ng-if="$ctrl.loading.screenshot"></oui-spinner>
                 <a data-ng-href="http://{{$ctrl.domain.name}}"
@@ -283,7 +283,7 @@
         </div>
     </div>
     <div class="row d-lg-flex" data-ng-if="!$ctrl.domain.isExpired">
-        <div class="col-xm-12 col-md-4 mb-5">
+        <div class="col-md-4 mb-5">
             <div class="d-flex flex-column-reverse flex-lg-column">
                 <div data-wuc-guides
                      data-wuc-guides-list="'generalInformations'"
@@ -291,6 +291,30 @@
                      data-tr="tr">
                 </div>
             </div>
+        </div>
+        <div class="col-md-4 mb-5">
+            <oui-tile
+                class="h-100"
+                data-heading="{{ ::'domain_dashboard_options' | translate }}"
+                data-loading="$ctrl.loading.options">
+                <oui-tile-definition data-term="{{ ::'domain_dashboard_options_dns_anycast' | translate }}">
+                    <oui-tile-description>
+                        <span data-ng-if="$ctrl.options.dnsAnycast"
+                              data-translate="{{ 'domain_dashboard_options_status_' + ($ctrl.options.dnsAnycast.optionActivated ? 'enabled' : 'disabled') }}">
+                        </span>
+                        <span data-ng-if="!$ctrl.options.dnsAnycast"
+                              data-translate="domain_dashboard_options_unavailable">
+                        </span>
+                    </oui-tile-description>
+                    <oui-action-menu data-compact data-align="end"
+                                     data-ng-if="$ctrl.options.dnsAnycast && $ctrl.options.dnsAnycast.optionActivated">
+                        <oui-action-menu-item data-text="{{ ::'domain_dashboard_options_desactivate_option' | translate }}"
+                            aria-label="{{ ::'domain_dashboard_options_desactivate_option' | translate }}"
+                            data-on-click="setAction('options/delete/domain-options-delete', { domain: $ctrl.domain, option: $ctrl.options.dnsAnycast })">
+                        </oui-action-menu-item>
+                    </oui-action-menu>
+                </oui-tile-definition>
+            </oui-tile>
         </div>
     </div>
 </div>

--- a/client/app/domain/general-informations/domain-general-informations.controller.js
+++ b/client/app/domain/general-informations/domain-general-informations.controller.js
@@ -48,6 +48,7 @@ export default class DomainTabGeneralInformationsCtrl {
     this.hasStart10mOffer = false;
     this.isAllDom = this.$rootScope.currentSectionInformation === 'all_dom';
     this.isUK = _.last(this.domain.name.split('.')).toUpperCase() === 'UK';
+    this.options = {};
     this.loading = {
       allDom: false,
       associatedHosting: false,
@@ -57,6 +58,7 @@ export default class DomainTabGeneralInformationsCtrl {
       domainInfos: this.$scope.ctrlDomain.loading.domainInfos,
       changeOwner: false,
       whoIs: false,
+      options: false,
     };
     this.initActions();
     this.dnsStatus = {
@@ -102,6 +104,7 @@ export default class DomainTabGeneralInformationsCtrl {
     this.$scope.$on('domain.dnssec.lock.unlock.cancel', () => {
       this.vm.dnssec.uiSwitch.checked = !this.vm.dnssec.uiSwitch.checked;
     });
+    this.$scope.$on('Domain.Options.Delete', () => this.getAllOptionDetails(this.domain.name));
 
     if (!this.domain.isExpired) {
       this.getScreenshoot(this.domain.name);
@@ -114,6 +117,7 @@ export default class DomainTabGeneralInformationsCtrl {
     this.getAllNameServer(this.domain.name);
     this.getHostingInfos(this.domain.name);
     this.getAssociatedHosting(this.domain.name);
+    this.getAllOptionDetails(this.domain.name);
     this.updateOwnerUrl = this.getUpdateOwnerUrl(this.domain);
 
     this.getRules();
@@ -307,6 +311,33 @@ export default class DomainTabGeneralInformationsCtrl {
       })
       .finally(() => {
         this.loading.associatedHosting = false;
+      });
+  }
+
+  getAllOptionDetails(serviceName) {
+    this.loading.options = true;
+    return this.Domain.getOptions(serviceName)
+      .then(options => this.$q.all(
+        _.map(options, option => this.Domain.getOption(serviceName, option)
+          .then((optionDetail) => {
+            _.set(optionDetail, 'optionActivated', optionDetail.state === this.DOMAIN.DOMAIN_OPTION_STATUS.ACTIVE);
+            return optionDetail;
+          })),
+      ))
+      .then((options) => {
+        const transformedOptions = {};
+        _.forEach(options, (option) => {
+          transformedOptions[option.option] = option;
+        });
+        this.options = transformedOptions;
+      })
+      .catch(err => this.Alerter.alertFromSWS(
+        this.$translate.instant('domain_configuration_web_hosting_fail'),
+        _.get(err, 'data'),
+        this.$scope.alerts.page,
+      ))
+      .finally(() => {
+        this.loading.options = false;
       });
   }
 

--- a/client/app/domain/options/delete/domain-options-delete.controller.js
+++ b/client/app/domain/options/delete/domain-options-delete.controller.js
@@ -1,0 +1,46 @@
+angular.module('controllers').controller(
+  'controllers.Domain.Options.Delete',
+  class DomainDnsLockCtrl {
+    constructor($scope, $rootScope, $translate, Alerter, Domain) {
+      this.$scope = $scope;
+      this.$rootScope = $rootScope;
+      this.$translate = $translate;
+      this.Alerter = Alerter;
+      this.Domain = Domain;
+    }
+
+    $onInit() {
+      this.loading = false;
+      this.domain = this.$scope.currentActionData.domain;
+      this.option = this.$scope.currentActionData.option;
+    }
+
+    closeModal() {
+      this.$scope.resetAction();
+    }
+
+    deleteDomain() {
+      this.loading = true;
+      return this.Domain.deleteOption(
+        this.domain.name,
+        this.option.option,
+      )
+        .then(() => this.Alerter.success(
+          this.$translate.instant('domain_tab_options_delete_success'),
+          this.$scope.alerts.main,
+        ))
+        .catch((err) => {
+          this.Alerter.alertFromSWS(
+            this.$translate.instant('domain_tab_options_delete_error'),
+            Object.assign({}, err, { type: err.type || 'ERROR' }),
+            this.$scope.alerts.main,
+          );
+        })
+        .finally(() => {
+          this.loading = false;
+          this.$rootScope.$broadcast('Domain.Options.Delete');
+          this.$scope.resetAction();
+        });
+    }
+  },
+);

--- a/client/app/domain/options/delete/domain-options-delete.html
+++ b/client/app/domain/options/delete/domain-options-delete.html
@@ -1,0 +1,16 @@
+<div data-ng-controller="controllers.Domain.Options.Delete as ctrl">
+    <oui-modal
+      data-heading="{{ ('domain_tab_options_delete_'+ctrl.option.option+'_title') | translate }}"
+      data-primary-action="ctrl.deleteDomain()"
+      data-primary-disabled="ctrl.loading"
+      data-primary-label="{{ 'domain_tab_options_delete_confirm_button' | translate }}"
+      data-secondary-action="ctrl.closeModal()"
+      data-secondary-disabled="ctrl.loading"
+      data-secondary-label="{{ 'domain_tab_options_delete_cancel' | translate }}"
+      data-on-dismiss="ctrl.closeModal()">
+        <p data-ng-if="!ctrl.loading" data-translate="domain_tab_options_delete_confirm"></p>
+        <div class="text-center" data-ng-if="ctrl.loading">
+            <oui-spinner></oui-spinner>
+        </div>
+    </oui-modal>
+</div>

--- a/client/app/domain/translations/Messages_fr_FR.json
+++ b/client/app/domain/translations/Messages_fr_FR.json
@@ -817,5 +817,18 @@
   "domain_dashboard_dns_activate_zone": "Activer la zone DNS",
   "domain_tab_dns_management_step1_updating": "La zone DNS est en cours de mise à jour ...",
   "domain_dashboard_general_informations": "Informations générales",
-  "domain_dashboard_general_security": "Sécurité"
+  "domain_dashboard_general_security": "Sécurité",
+  "domain_dashboard_options": "Résumé des options",
+  "domain_dashboard_options_dns_anycast": "DNS Anycast",
+  "domain_dashboard_options_status_enabled": "Activé",
+  "domain_dashboard_options_status_disabled": "Désactivé",
+  "domain_dashboard_options_unavailable": "Option non disponible",
+  "domain_dashboard_options_desactivate_option": "Résilier",
+  "domain_dashboard_options_fail": "Une erreur est survenue lors de la récupération des options de domaine",
+  "domain_tab_options_delete_confirm": "Voulez-vous vraiment supprimer l'option ?",
+  "domain_tab_options_delete_confirm_button": "Confirmer",
+  "domain_tab_options_delete_dnsAnycast_title": "Résilier l'option DNS Anycast",
+  "domain_tab_options_delete_success": "L'option a été résiliée.",
+  "domain_tab_options_delete_error": "Une erreur est survenue lors de la résiliation de l'option.",
+  "domain_tab_options_delete_cancel": "Annuler"
 }


### PR DESCRIPTION
MBP-460

### Requirements

* The APIs for domain options have been added. Hence the domain options have to be exposed to the user via a new tile in the domain dashboard page.
* Currently, only dnsAnycast is supported. This the user will only be able to delete the option, if it is activated.

## Addition of Options tile to Domain

### Description of the Change

The domain options tile has been added as per requirement.