### PR TITLE
build(deps): upgrade ovh-api-services to v8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "ovh-angular-responsive-tabs": "ovh-ux/ovh-angular-responsive-tabs#^4.0.0",
     "ovh-angular-tail-logs": "^1.1.1",
     "ovh-angular-toaster": "ovh-ux/ovh-angular-toaster#^0.8.0",
-    "ovh-api-services": "^7.0.0",
+    "ovh-api-services": "^8.0.0",
     "ovh-jquery-ui-draggable-ng": "ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5",
     "ovh-manager-webfont": "ovh-ux/ovh-manager-webfont#^1.0.1",
     "ovh-module-emailpro": "^7.2.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7010,6 +7010,11 @@ lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -8185,12 +8190,12 @@ ovh-angular-toaster@ovh-ux/ovh-angular-toaster#^0.8.0:
   version "0.8.0"
   resolved "https://codeload.github.com/ovh-ux/ovh-angular-toaster/tar.gz/06d24889e94b8d816afee8e94185697cf68f2338"
 
-ovh-api-services@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-7.0.0.tgz#240ced6f8930eed94b4484aa558ad8f432af537f"
-  integrity sha512-aC2NDo9Rf7iwJvfnoPJ2E9Rtrv7Yy7tNXFJv4PifBqyUefjbTAUCfDNRrxgVnpOmPJ1h5SWjx19t3T/6w8qVDw==
+ovh-api-services@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ovh-api-services/-/ovh-api-services-8.0.0.tgz#494d33d5896567e1d944f380931733f8ae4d18f5"
+  integrity sha512-1eO4z2+T4mWalDlSjwC/c4ZiG4YwFfky9jSbtVR4sRXWOowegJ5uhzlIR1tQocOjioNBsYpF17K2zxQRVVmwLw==
   dependencies:
-    lodash "^3.10.1"
+    lodash "^4.17.15"
 
 ovh-jquery-ui-draggable-ng@ovh-ux/ovh-jquery-ui-draggable-ng#^0.0.5:
   version "0.0.5"


### PR DESCRIPTION
# Upgrade ovh-api-services to v8.0.0

## :arrow_up: Upgrade

96e7d43 - build(deps): upgrade ovh-api-services to v8.0.0

uses: `yarn upgrade-interactive --latest`
- ovh-api-services@8.0.0

## :house: Internal

- No QC required.
