### PR TITLE
fix(layout): display skipnav translation correctly

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -12,7 +12,7 @@
             <!-- Skip to main content -->
             <div class="skipnav">
                 <a class="oui-button oui-button_link" href=""
-                   data-ng-bind="::i18n.common_skip_to_main_content"
+                   data-translate="common_skip_to_main_content"
                    data-ng-click="scrollTo('maincontent')">
                 </a>
             </div>


### PR DESCRIPTION
# Display skipnav translation correctly

## 🐛 Bug Fix

5738baa - fix(layout): display skipnav translation correctly

## 📷 Screenshot

**Before:**
![web-skipnav-before](https://user-images.githubusercontent.com/428384/62833401-777a2a80-bc3e-11e9-9629-70d40c27d725.png)

**After:**
![web-skipnav-after](https://user-images.githubusercontent.com/428384/62833403-7cd77500-bc3e-11e9-8c47-06999c876b9d.png)

## 🔗 Related

fix #1193
