### PR TITLE
fix: remove ng-ovh-otrs dependency

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -106,7 +106,6 @@ angular
     DOMAIN: config.constants.DOMAIN,
     WEBSITE_URLS: config.constants.website_url,
     new_bdd_user_grant_options: config.constants.new_bdd_user_grant_options,
-    REDIRECT_URLS: config.constants.REDIRECT_URLS,
   })
   .constant('LANGUAGES', config.constants.LANGUAGES)
   .constant('website_url', config.constants.website_url)

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -16,7 +16,6 @@ import ngUiRouterLayout from '@ovh-ux/ng-ui-router-layout';
 import ngUiRouterLineProgress from '@ovh-ux/ng-ui-router-line-progress';
 import ovhManagerNavbar from '@ovh-ux/manager-navbar';
 import uiRouter from '@uirouter/angularjs';
-import ngOvhOtrs from '@ovh-ux/ng-ovh-otrs';
 import ovhManagerServerSidebar from '@ovh-ux/manager-server-sidebar';
 import domainEmailObfuscation from './domain/email-obfuscation/index';
 import domainOptin from './domain/optin/index';
@@ -65,7 +64,6 @@ angular
     'pascalprecht.translate',
     'ovh-angular-responsive-tabs',
     'ovh-angular-tail-logs',
-    ngOvhOtrs,
     'ovh-api-services',
     'ovh-angular-toaster',
     ovhManagerNavbar,
@@ -433,9 +431,6 @@ angular
     // overwrite submit button template
     _.set(editableThemes, 'default.submitTpl', ['<button style="background:none;border:none" type="submit">', '<i class="fa fa-check green"></i>', '</button>'].join(''));
     _.set(editableThemes, 'default.cancelTpl', ['<button style="background:none;border:none" ng-click="$form.$cancel()">', '<i class="fa fa-times red"></i>', '</button>'].join(''));
-  })
-  .config((OtrsPopupProvider, constants) => {
-    OtrsPopupProvider.setBaseUrlTickets(_.get(constants, 'REDIRECT_URLS.listTicket', null));
   })
   .constant('UNIVERSE', 'WEB')
   .constant('MANAGER_URLS', {

--- a/client/app/config/constants.config.js
+++ b/client/app/config/constants.config.js
@@ -899,9 +899,6 @@ module.exports = {
             "TN",
             "SN"
         ],
-        REDIRECT_URLS: {
-            listTicket: "https://www.ovh.com/manager/dedicated/index.html#/ticket"
-        }
     },
     CA: {
         AUTORENEW_URL: "https://ca.ovh.com/manager/dedicated/#/billing/autoRenew",
@@ -1130,8 +1127,5 @@ module.exports = {
             "TN",
             "SN"
         ],
-        REDIRECT_URLS: {
-            listTicket: "https://ca.ovh.com/manager/index.html#/ticket"
-        }
     }
 };

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -82,7 +82,6 @@
             </div>
         </div>
 
-        <div data-otrs-popup></div>
         <script>
          var CKEDITOR_BASEPATH = (window.location.pathname !== "/" ? window.location.pathname.split("/").splice(0, window.location.pathname.split("/").length - 1).join("/") : "") + '/ckeditor/';
         </script>

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@ovh-ux/ng-ovh-chatbot": "^2.0.0",
     "@ovh-ux/ng-ovh-cloud-universe-components": "^1.3.0-alpha.4",
     "@ovh-ux/ng-ovh-http": "^4.0.2",
-    "@ovh-ux/ng-ovh-otrs": "^7.1.6",
     "@ovh-ux/ng-ovh-payment-method": "^3.2.0",
     "@ovh-ux/ng-ovh-proxy-request": "^1.0.0-beta.0",
     "@ovh-ux/ng-ovh-request-tagger": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,14 +1225,6 @@
     lodash "~4.17.15"
     urijs "^1.19.1"
 
-"@ovh-ux/ng-ovh-otrs@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-otrs/-/ng-ovh-otrs-7.1.6.tgz#be254726ea7c5cbb933a28a422fa0d2f7426691c"
-  integrity sha512-GR2y+1zAFL2YZRkMra6I6crGMPDBUsbYpy5dqiCenK5KEx+cU+0iGSFQp0HFXRTPZkRMwfF/NN1jXI9m/tV+Uw==
-  dependencies:
-    draggable "^4.2.0"
-    lodash "^4.17.11"
-
 "@ovh-ux/ng-ovh-payment-method@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@ovh-ux/ng-ovh-payment-method/-/ng-ovh-payment-method-3.2.0.tgz#a36b20c0c12e5d87cde1ff095a598b3f7b7e4514"
@@ -3863,11 +3855,6 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
-
-draggable@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/draggable/-/draggable-4.2.0.tgz#149c0ca176df6d8b512048c8e451f499fc047b9a"
-  integrity sha1-FJwMoXbfbYtRIEjI5FH0mfwEe5o=
 
 drange@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
# Remove ng-ovh-otrs dependency

Since the OtrsPopup can only be accessible from the Dedicated Control panel,
there is no reason to keep the `otrs-popup` directive.

## :bug: Bug Fix

8708fdd - fix: remove ng-ovh-otrs dependency

## :link: Related

MANAGER-2710

## :house: Internal

- No QC required.